### PR TITLE
Remember tunnel targets and fix remote OpenCode runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+## Project Overview
+codebox is a Bun-powered CLI that rsyncs a local workspace to a remote host and bootstraps Codex/OpenCode tooling using Devbox. It also syncs optional configs (Codex, OpenCode, GH, SSH) and environment variables.
+
+## Key Files
+- `codebox.ts` - main CLI implementation, rsync/ssh orchestration, env sync, and remote bootstrap script.
+- `bin/codebox` - npm-installed CLI entrypoint (Bun shebang).
+- `package.json` - npm metadata, bin mapping, and test script.
+- `tests/integration/install.test.mjs` - integration test that verifies install exposes `codebox` on PATH.
+- `README.md` - installation and usage documentation.
+- `LICENSE` - license.
+
+## How To Test
+- `npm test`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ npm install -g .
 ```sh
 codebox --remote azureuser@dev-1 --base '$HOME/workspace'
 codebox --remote azureuser@dev-1 --exclude '.android-sdk-fixed' --exclude '.gradle-home' --opencode-supervisor systemd
-codebox --remote azureuser@dev-1 --opencode-repo-url https://github.com/dzianisv/opencode.git
+codebox --remote azureuser@dev-1 --opencode-repo-url https://github.com/dzianisv/opencode.git --opencode-ref dev
+codebox --remote azureuser@dev-1 --opencode-src ~/workspace/opencode
 ```
 
 Quick SSH access to the synced repo on remote:
@@ -69,7 +70,9 @@ codebox tunnel --all
   - disable with `--no-opencode-tunnel`
   - override ports with `--opencode-local-port <n>` and `--opencode-remote-port <n>`
   - when the preferred local port is already occupied, `codebox` automatically picks the next free localhost port and remembers it for that remote target
-- The remote OpenCode checkout is anchored to `https://github.com/dzianisv/opencode.git` by default. If you sync a local `--opencode-src`, it must also point at that fork unless you intentionally override `--opencode-repo-url`.
+- The default OpenCode deployment source is the managed remote checkout of `https://github.com/dzianisv/opencode.git` at ref `dev`.
+- Use `--opencode-ref <branch|sha>` to deploy another branch or commit from that fork.
+- Use `--opencode-src <path>` only when you intentionally want a local checkout to override the managed remote checkout. If you do, its `origin` must still point at the same fork unless you intentionally override `--opencode-repo-url`.
 - When the fork checkout exposes an `install:local` hook, `codebox` installs that build on the VM and prefers `~/.local/bin/opencode` before any downloaded `~/.opencode/bin/opencode` channel binary.
 - Remote OpenCode startup defaults `OPENCODE_DISABLE_CHANNEL_DB=1` unless you override it, so switching between downloaded and repo-local builds keeps using the shared `opencode.db` state.
 - When OpenCode config sync is enabled, `codebox` also syncs `~/.local/share/opencode/auth.json` so GitHub Copilot-backed remote sessions keep working.

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ codebox tunnel --all
   - when the preferred local port is already occupied, `codebox` automatically picks the next free localhost port and remembers it for that remote target
 - The remote OpenCode checkout is anchored to `https://github.com/dzianisv/opencode.git` by default. If you sync a local `--opencode-src`, it must also point at that fork unless you intentionally override `--opencode-repo-url`.
 - When the fork checkout exposes an `install:local` hook, `codebox` installs that build on the VM and prefers `~/.local/bin/opencode` before any downloaded `~/.opencode/bin/opencode` channel binary.
+- Remote OpenCode startup defaults `OPENCODE_DISABLE_CHANNEL_DB=1` unless you override it, so switching between downloaded and repo-local builds keeps using the shared `opencode.db` state.
 - When OpenCode config sync is enabled, `codebox` also syncs `~/.local/share/opencode/auth.json` so GitHub Copilot-backed remote sessions keep working.
 - Remote OpenCode supervision is configurable with `--opencode-supervisor auto|nohup|systemd`:
   - `auto` prefers `systemd --user` and falls back to `nohup`
-  - `systemd` installs/refreshes `opencode-serve.service`, runs it from the remote workspace root, stops it before reinstalling `opencode`, and tries to enable user lingering
-  - `nohup` keeps the old one-shot background behavior
+  - `systemd` installs/refreshes `opencode-serve.service`, runs it from the remote OpenCode checkout, stops it before reinstalling `opencode`, and tries to enable user lingering
+  - `nohup` keeps the one-shot background behavior, but still starts from the remote OpenCode checkout so repo-built frontend assets are served
 
 Install Jetify `devbox` CLI into your Bun local bin path:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm install -g .
 
 ```sh
 codebox --remote azureuser@dev-1 --base '$HOME/workspace'
+codebox --remote azureuser@dev-1 --exclude '.android-sdk-fixed' --exclude '.gradle-home' --opencode-supervisor systemd
+codebox --remote azureuser@dev-1 --opencode-repo-url https://github.com/dzianisv/opencode.git
 ```
 
 Quick SSH access to the synced repo on remote:
@@ -40,6 +42,9 @@ Dedicated tunnel command (starts/reuses background tunnel and returns):
 ```sh
 codebox tunnel
 codebox tunnel --opencode-local-port 4097 --opencode-remote-port 4097
+codebox tunnel --repo termux-app
+codebox tunnel --list
+codebox tunnel --all
 ```
 
 ## Notes
@@ -49,15 +54,28 @@ codebox tunnel --opencode-local-port 4097 --opencode-remote-port 4097
 - `codebox ssh` auto-enters `$BASE/<current-folder>` on remote when that directory exists.
 - In `codebox ssh` mode, unknown flags are passed through to `ssh` (for example `-L`, `-R`, `-D`, `-N`, `-p`, `-i`).
 - `codebox tunnel` is the simplest way to pin the OpenCode tunnel in the background.
+- `codebox tunnel --repo <name>` lets you target a remembered repo from any working directory instead of implicitly using the current folder name.
+- `codebox` now remembers synced/tunneled remote targets in `~/.config/codebox.json`, including VM hostname, repo, SSH opts, and the localhost OpenCode port mapping.
+- `codebox tunnel --list` shows remembered targets with VM name, repo, localhost URL, remote port, and current status.
+- `codebox tunnel --all` reconciles background OpenCode tunnels for every remembered target instead of only the most recent one.
 - Syncs `.git` by default so the remote is a real git repo.
 - Excludes `codex-rs/target*`, `node_modules`, `dist`, `.venv` by default.
-- Syncs env vars into remote `~/.bashrc` (defaults include `GITHUB_TOKEN`, `OPENAI_*`, `AZURE_OPENAI_*`, `OPENCODE_*`, `CODEX_*`, and any `*_TOKEN`). Use `--no-env`, `--env`, `--env-prefix` to control.
+- Supports repeatable `--exclude` flags for repo-local heavyweight directories that should stay local.
+- Syncs env vars into a managed remote shell/OpenCode env file and wires remote `~/.bashrc` to source it (defaults include `GITHUB_TOKEN`, `OPENAI_*`, `AZURE_OPENAI_*`, `OPENCODE_*`, `CODEX_*`, and any `*_TOKEN`). Use `--no-env`, `--env`, `--env-prefix` to control.
 - Prompts before syncing secrets or `~/.ssh` unless `--yes` is provided.
 - Use `-v/--verbose` for rsync progress output.
 - Sync mode now ensures OpenCode is running on remote (`127.0.0.1:5551`) and starts a background local SSH tunnel by default:
   - `localhost:5551 -> remote:127.0.0.1:5551`
   - disable with `--no-opencode-tunnel`
   - override ports with `--opencode-local-port <n>` and `--opencode-remote-port <n>`
+  - when the preferred local port is already occupied, `codebox` automatically picks the next free localhost port and remembers it for that remote target
+- The remote OpenCode checkout is anchored to `https://github.com/dzianisv/opencode.git` by default. If you sync a local `--opencode-src`, it must also point at that fork unless you intentionally override `--opencode-repo-url`.
+- When the fork checkout exposes an `install:local` hook, `codebox` installs that build on the VM and prefers `~/.local/bin/opencode` before any downloaded `~/.opencode/bin/opencode` channel binary.
+- When OpenCode config sync is enabled, `codebox` also syncs `~/.local/share/opencode/auth.json` so GitHub Copilot-backed remote sessions keep working.
+- Remote OpenCode supervision is configurable with `--opencode-supervisor auto|nohup|systemd`:
+  - `auto` prefers `systemd --user` and falls back to `nohup`
+  - `systemd` installs/refreshes `opencode-serve.service`, runs it from the remote workspace root, stops it before reinstalling `opencode`, and tries to enable user lingering
+  - `nohup` keeps the old one-shot background behavior
 
 Install Jetify `devbox` CLI into your Bun local bin path:
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ npm install -g .
 ## Usage
 
 ```sh
-codebox --remote azureuser@dev-1 --base '$HOME/workspace'
-codebox --remote azureuser@dev-1 --exclude '.android-sdk-fixed' --exclude '.gradle-home' --opencode-supervisor systemd
+codebox --remote azureuser@dev-1
+codebox --remote azureuser@dev-1 --exclude '.android-sdk-fixed' --exclude '.gradle-home'
 codebox --remote azureuser@dev-1 --opencode-repo-url https://github.com/dzianisv/opencode.git --opencode-ref dev
 codebox --remote azureuser@dev-1 --opencode-src ~/workspace/opencode
 ```
@@ -32,11 +32,13 @@ codebox ssh azureuser@dev-1 -- git status -sb
 codebox ssh -L 4097:127.0.0.1:4097 -N
 ```
 
-If you don't pass `--remote`, the last used remote is loaded from:
+If you don't pass `--remote`, remembered targets are loaded from:
 
 ```
 ~/.config/codebox.json
 ```
+
+If the current repo already has remembered VM targets, `codebox` picks from those first. In a TTY it shows a numbered chooser; in non-interactive mode it falls back to the most recent remembered target.
 
 Dedicated tunnel command (starts/reuses background tunnel and returns):
 
@@ -76,9 +78,9 @@ codebox tunnel --all
 - When the fork checkout exposes an `install:local` hook, `codebox` installs that build on the VM and prefers `~/.local/bin/opencode` before any downloaded `~/.opencode/bin/opencode` channel binary.
 - Remote OpenCode startup defaults `OPENCODE_DISABLE_CHANNEL_DB=1` unless you override it, so switching between downloaded and repo-local builds keeps using the shared `opencode.db` state.
 - When OpenCode config sync is enabled, `codebox` also syncs `~/.local/share/opencode/auth.json` so GitHub Copilot-backed remote sessions keep working.
-- Remote OpenCode supervision is configurable with `--opencode-supervisor auto|nohup|systemd`:
-  - `auto` prefers `systemd --user` and falls back to `nohup`
+- Remote OpenCode supervision defaults to `systemd`; use `--opencode-supervisor auto|nohup|systemd` to override:
   - `systemd` installs/refreshes `opencode-serve.service`, runs it from the remote OpenCode checkout, stops it before reinstalling `opencode`, and tries to enable user lingering
+  - `auto` prefers `systemd --user` and falls back to `nohup`
   - `nohup` keeps the one-shot background behavior, but still starts from the remote OpenCode checkout so repo-built frontend assets are served
 
 Install Jetify `devbox` CLI into your Bun local bin path:

--- a/codebox.ts
+++ b/codebox.ts
@@ -3,17 +3,24 @@ import { basename, resolve } from "node:path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 
+type OpencodeSupervisor = "auto" | "nohup" | "systemd";
+const DEFAULT_OPENCODE_REPO_URL = "https://github.com/dzianisv/opencode.git";
+
 type Options = {
   remote: string;
   sshOpts: string;
   base: string;
   opencodeSrc?: string;
+  opencodeRepoUrl: string;
+  repoExcludes: string[];
   opencodeTunnel: boolean;
   opencodeLocalPort: number;
   opencodeRemotePort: number;
+  opencodeSupervisor: OpencodeSupervisor;
   syncGit: boolean;
   syncCodexConfig: boolean;
   syncOpencodeConfig: boolean;
+  syncOpencodeAuth: boolean;
   syncGhConfig: boolean;
   syncSshKeys: boolean;
   includeCodexHistory: boolean;
@@ -23,6 +30,33 @@ type Options = {
   verbose: boolean;
   dryRun: boolean;
   configPath: string;
+};
+
+type CodeboxConfig = Record<string, unknown>;
+
+type KnownTarget = {
+  remote: string;
+  remoteHost?: string;
+  sshOpts?: string;
+  base: string;
+  repo: string;
+  remoteRepo: string;
+  opencodeLocalPort: number;
+  opencodeRemotePort: number;
+  lastSyncedAt?: string;
+  lastTunneledAt?: string;
+  updatedAt?: string;
+};
+
+type TunnelPortInspection =
+  | { state: "free" }
+  | { state: "expected" }
+  | { state: "occupied"; usage?: string };
+
+type KnownTargetSelector = {
+  repo?: string;
+  remote?: string;
+  base?: string;
 };
 
 function usage(): string {
@@ -35,17 +69,24 @@ Options:
   --remote <user@host>        SSH target (required for sync mode)
   --ssh-opts <string>         SSH options (default: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes")
   --base <path>               Remote base dir (default: "$HOME/workspace")
+  --repo <name>               Tunnel mode only: remembered repo to target instead of current working directory
   --opencode-src <path>       Local opencode repo path (default: ~/workspace/opencode if exists)
+  --opencode-repo-url <url>   OpenCode git remote to anchor on the target (default: "${DEFAULT_OPENCODE_REPO_URL}")
+  --exclude <pattern>         Extra repo rsync exclude pattern (repeatable)
   --no-opencode-tunnel        Skip auto-starting localhost SSH tunnel to remote OpenCode
   --opencode-local-port <n>   Local forwarded port (default: 5551)
   --opencode-remote-port <n>  Remote OpenCode port (default: 5551)
+  --opencode-supervisor <m>   Remote OpenCode supervisor: auto|nohup|systemd (default: auto)
+  --list                      Tunnel mode only: show remembered tunnel targets
+  --all                       Tunnel mode only: start/reconcile all remembered tunnel targets
   --no-git                    Do NOT sync .git (default: sync .git)
   --no-codex-config           Skip syncing ~/.codex
   --no-opencode-config        Skip syncing ~/.config/opencode and ~/.opencode
+  --no-opencode-auth          Skip syncing ~/.local/share/opencode auth state
   --no-gh-config              Skip syncing ~/.config/gh
   --sync-ssh                  Sync ~/.ssh (includes private keys) [off by default]
   --include-codex-history     Include ~/.codex/history.jsonl (default: excluded)
-  --no-env                    Do NOT sync env vars to remote ~/.bashrc
+  --no-env                    Do NOT sync env vars to the remote shell/OpenCode env
   --env <NAME>                Also sync a specific env var (repeatable)
   --env-prefix <PREFIX>       Sync env vars with this prefix (repeatable)
   --yes                       Assume yes for prompts (env/ssh sync)
@@ -61,6 +102,9 @@ Example:
   ./codebox.ts ssh -L 4097:127.0.0.1:4097 -N
   ./codebox.ts tunnel
   ./codebox.ts tunnel azureuser@dev-1 --opencode-local-port 4097 --opencode-remote-port 4097
+  ./codebox.ts tunnel --repo termux-app
+  ./codebox.ts tunnel --list
+  ./codebox.ts tunnel --all
   ./codebox.ts ssh --remote azureuser@dev-1 -- git status -sb
 `;
 }
@@ -106,6 +150,196 @@ function writeConfig(path: string, data: Record<string, unknown>) {
   const dir = path.replace(/\/[^/]+$/, "");
   mkdirSync(dir, { recursive: true });
   writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function knownTargetKey(remote: string, base: string, repo: string): string {
+  return `${remote}::${base}::${repo}`;
+}
+
+function parseKnownTarget(value: unknown): KnownTarget | undefined {
+  if (!isRecord(value)) return undefined;
+  const remote = typeof value.remote === "string" ? value.remote : undefined;
+  const base = typeof value.base === "string" ? value.base : undefined;
+  const repo = typeof value.repo === "string" ? value.repo : undefined;
+  const remoteRepo =
+    typeof value.remoteRepo === "string" ? value.remoteRepo : undefined;
+  const opencodeLocalPort =
+    typeof value.opencodeLocalPort === "number" ? value.opencodeLocalPort : undefined;
+  const opencodeRemotePort =
+    typeof value.opencodeRemotePort === "number" ? value.opencodeRemotePort : undefined;
+
+  if (
+    !remote ||
+    !base ||
+    !repo ||
+    !remoteRepo ||
+    !Number.isInteger(opencodeLocalPort) ||
+    !Number.isInteger(opencodeRemotePort)
+  ) {
+    return undefined;
+  }
+
+  return {
+    remote,
+    remoteHost: typeof value.remoteHost === "string" ? value.remoteHost : undefined,
+    sshOpts: typeof value.sshOpts === "string" ? value.sshOpts : undefined,
+    base,
+    repo,
+    remoteRepo,
+    opencodeLocalPort,
+    opencodeRemotePort,
+    lastSyncedAt:
+      typeof value.lastSyncedAt === "string" ? value.lastSyncedAt : undefined,
+    lastTunneledAt:
+      typeof value.lastTunneledAt === "string" ? value.lastTunneledAt : undefined,
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : undefined,
+  };
+}
+
+function getKnownTargetMap(config: CodeboxConfig): Record<string, KnownTarget> {
+  const raw = isRecord(config.known_targets) ? config.known_targets : {};
+  const known: Record<string, KnownTarget> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const parsed = parseKnownTarget(value);
+    if (parsed) {
+      known[key] = parsed;
+    }
+  }
+  return known;
+}
+
+function getKnownTargetEntries(config: CodeboxConfig): Array<[string, KnownTarget]> {
+  return Object.entries(getKnownTargetMap(config));
+}
+
+function findKnownTarget(
+  config: CodeboxConfig,
+  remote: string,
+  base: string,
+  repo: string,
+): { key: string; target: KnownTarget } | undefined {
+  const key = knownTargetKey(remote, base, repo);
+  const target = getKnownTargetMap(config)[key];
+  return target ? { key, target } : undefined;
+}
+
+function selectKnownTargets(
+  config: CodeboxConfig,
+  selector: KnownTargetSelector,
+): KnownTarget[] {
+  return getKnownTargetEntries(config)
+    .map(([, target]) => target)
+    .filter((target) => {
+      if (selector.repo && target.repo !== selector.repo) return false;
+      if (selector.remote && target.remote !== selector.remote) return false;
+      if (selector.base && target.base !== selector.base) return false;
+      return true;
+    })
+    .sort((left, right) => {
+      const a = left.updatedAt ?? left.lastTunneledAt ?? left.lastSyncedAt ?? "";
+      const b = right.updatedAt ?? right.lastTunneledAt ?? right.lastSyncedAt ?? "";
+      return b.localeCompare(a);
+    });
+}
+
+function canShareTunnel(a: KnownTarget, b: Pick<KnownTarget, "remote" | "opencodeRemotePort">): boolean {
+  return a.remote === b.remote && a.opencodeRemotePort === b.opencodeRemotePort;
+}
+
+function findSharedTunnelTarget(
+  config: CodeboxConfig,
+  needle: Pick<KnownTarget, "remote" | "opencodeRemotePort">,
+): KnownTarget | undefined {
+  const entries = getKnownTargetEntries(config)
+    .map(([, target]) => target)
+    .filter((target) => canShareTunnel(target, needle))
+    .sort((left, right) => {
+      const a = left.lastTunneledAt ?? left.updatedAt ?? left.lastSyncedAt ?? "";
+      const b = right.lastTunneledAt ?? right.updatedAt ?? right.lastSyncedAt ?? "";
+      return b.localeCompare(a);
+    });
+  return entries[0];
+}
+
+function isReservedByOtherTarget(
+  config: CodeboxConfig,
+  port: number,
+  current: Pick<KnownTarget, "remote" | "base" | "repo" | "opencodeRemotePort">,
+): boolean {
+  const currentKey = knownTargetKey(current.remote, current.base, current.repo);
+  for (const [key, target] of getKnownTargetEntries(config)) {
+    if (key === currentKey) continue;
+    if (target.opencodeLocalPort !== port) continue;
+    if (canShareTunnel(target, current)) continue;
+    return true;
+  }
+  return false;
+}
+
+function choosePreferredTunnelLocalPort(params: {
+  config: CodeboxConfig;
+  remote: string;
+  base: string;
+  repo: string;
+  remotePort: number;
+  explicitLocalPort?: number;
+  fallbackLocalPort: number;
+}): number {
+  if (params.explicitLocalPort != null) {
+    return params.explicitLocalPort;
+  }
+
+  const current = findKnownTarget(params.config, params.remote, params.base, params.repo);
+  if (current) {
+    return current.target.opencodeLocalPort;
+  }
+
+  const shared = findSharedTunnelTarget(params.config, {
+    remote: params.remote,
+    opencodeRemotePort: params.remotePort,
+  });
+  if (shared) {
+    return shared.opencodeLocalPort;
+  }
+
+  let candidate = params.fallbackLocalPort;
+  while (
+    isReservedByOtherTarget(params.config, candidate, {
+      remote: params.remote,
+      base: params.base,
+      repo: params.repo,
+      opencodeRemotePort: params.remotePort,
+    })
+  ) {
+    candidate += 1;
+  }
+  return candidate;
+}
+
+function upsertKnownTarget(
+  config: CodeboxConfig,
+  target: KnownTarget,
+  updatedAt: string,
+): CodeboxConfig {
+  const knownTargets = getKnownTargetMap(config);
+  const key = knownTargetKey(target.remote, target.base, target.repo);
+  knownTargets[key] = {
+    ...knownTargets[key],
+    ...target,
+    updatedAt,
+  };
+  return {
+    ...config,
+    last_remote: target.remote,
+    last_base: target.base,
+    last_repo: target.repo,
+    updated_at: updatedAt,
+    known_targets: knownTargets,
+  };
 }
 
 function bashQuote(value: string): string {
@@ -193,6 +427,16 @@ function parsePort(raw: string | undefined, name: string, fallback: number): num
   return value;
 }
 
+function parseOpencodeSupervisor(raw: string | undefined): OpencodeSupervisor {
+  const text = (raw ?? "auto").trim().toLowerCase();
+  if (text === "" || text === "auto") return "auto";
+  if (text === "nohup") return "nohup";
+  if (text === "systemd") return "systemd";
+  throw new Error(
+    `Invalid --opencode-supervisor: "${raw ?? ""}" (expected auto, nohup, or systemd)`,
+  );
+}
+
 function shellSplit(input: string): string[] {
   const out: string[] = [];
   let cur = "";
@@ -251,9 +495,12 @@ function findPositionalRemote(args: string[]): string | undefined {
     "--remote",
     "--ssh-opts",
     "--base",
+    "--repo",
     "--opencode-src",
+    "--opencode-repo-url",
     "--opencode-local-port",
     "--opencode-remote-port",
+    "--opencode-supervisor",
     "--config",
     "--env",
     "--env-prefix",
@@ -287,9 +534,12 @@ function parseSshModeArgs(rawArgs: string[]): ParsedSshModeArgs {
     "--remote",
     "--ssh-opts",
     "--base",
+    "--repo",
     "--opencode-src",
+    "--opencode-repo-url",
     "--opencode-local-port",
     "--opencode-remote-port",
+    "--opencode-supervisor",
     "--config",
     "--env",
     "--env-prefix",
@@ -299,6 +549,7 @@ function parseSshModeArgs(rawArgs: string[]): ParsedSshModeArgs {
     "--no-git",
     "--no-codex-config",
     "--no-opencode-config",
+    "--no-opencode-auth",
     "--no-gh-config",
     "--sync-ssh",
     "--include-codex-history",
@@ -446,6 +697,27 @@ async function runCapture(
   return { code, stdout, stderr };
 }
 
+function canonicalGitRemoteUrl(url: string): string {
+  const trimmed = url.trim().replace(/\/+$/, "").replace(/\.git$/i, "");
+  if (trimmed.startsWith("git@github.com:")) {
+    return trimmed.slice("git@github.com:".length).toLowerCase();
+  }
+  if (trimmed.startsWith("ssh://git@github.com/")) {
+    return trimmed.slice("ssh://git@github.com/".length).toLowerCase();
+  }
+  if (trimmed.startsWith("https://github.com/")) {
+    return trimmed.slice("https://github.com/".length).toLowerCase();
+  }
+  return trimmed.toLowerCase();
+}
+
+async function readGitRemoteUrl(repoDir: string, remoteName: string): Promise<string | undefined> {
+  const result = await runCapture(["git", "-C", repoDir, "remote", "get-url", remoteName]);
+  if (result.code !== 0) return undefined;
+  const url = result.stdout.trim();
+  return url === "" ? undefined : url;
+}
+
 async function listListeningPids(port: number): Promise<number[]> {
   const result = await runCapture([
     "lsof",
@@ -507,36 +779,95 @@ function buildTunnelCommand(params: {
   ];
 }
 
+async function inspectTunnelPort(params: {
+  remote: string;
+  localPort: number;
+  remotePort: number;
+}): Promise<TunnelPortInspection> {
+  const pids = await listListeningPids(params.localPort);
+  if (pids.length === 0) {
+    return { state: "free" };
+  }
+
+  for (const pid of pids) {
+    const desc = await describePid(pid);
+    const isSshProcess = /\bssh\b/.test(desc);
+    if (
+      isSshProcess &&
+      desc.includes(params.remote) &&
+      desc.includes(`${params.localPort}:127.0.0.1:${params.remotePort}`)
+    ) {
+      return { state: "expected" };
+    }
+  }
+
+  return {
+    state: "occupied",
+    usage: (await getPortUsageSummary(params.localPort)) ?? undefined,
+  };
+}
+
+async function resolveTunnelLocalPort(params: {
+  config: CodeboxConfig;
+  remote: string;
+  base: string;
+  repo: string;
+  localPort: number;
+  localPortExplicit: boolean;
+  remotePort: number;
+}): Promise<number> {
+  let candidate = params.localPort;
+  for (; candidate <= 65535; candidate += 1) {
+    const inspection = await inspectTunnelPort({
+      remote: params.remote,
+      localPort: candidate,
+      remotePort: params.remotePort,
+    });
+    if (inspection.state === "expected") {
+      return candidate;
+    }
+    if (inspection.state === "occupied") {
+      if (params.localPortExplicit) {
+        throw new Error(
+          `Cannot start OpenCode tunnel: localhost:${candidate} is already in use (${inspection.usage ?? "unknown process"}).`,
+        );
+      }
+      continue;
+    }
+    if (
+      !isReservedByOtherTarget(params.config, candidate, {
+        remote: params.remote,
+        base: params.base,
+        repo: params.repo,
+        opencodeRemotePort: params.remotePort,
+      })
+    ) {
+      return candidate;
+    }
+  }
+  throw new Error("Unable to find a free localhost port for the OpenCode tunnel.");
+}
+
 async function ensureBackgroundTunnel(params: {
   remote: string;
   sshOpts: string;
   localPort: number;
   remotePort: number;
-}): Promise<void> {
-  const pids = await listListeningPids(params.localPort);
-  if (pids.length > 0) {
-    let hasExpectedTunnel = false;
-    for (const pid of pids) {
-      const desc = await describePid(pid);
-      const isSshProcess = /\bssh\b/.test(desc);
-      if (
-        isSshProcess &&
-        desc.includes(params.remote) &&
-        desc.includes(`${params.localPort}:127.0.0.1:${params.remotePort}`)
-      ) {
-        hasExpectedTunnel = true;
-        break;
-      }
-    }
-    if (hasExpectedTunnel) {
-      console.log(
-        `[codebox] Reusing existing OpenCode tunnel on localhost:${params.localPort}`,
-      );
-      return;
-    }
-    const usage = await getPortUsageSummary(params.localPort);
+}): Promise<"reused" | "started"> {
+  const inspection = await inspectTunnelPort({
+    remote: params.remote,
+    localPort: params.localPort,
+    remotePort: params.remotePort,
+  });
+  if (inspection.state === "expected") {
+    console.log(
+      `[codebox] Reusing existing OpenCode tunnel on localhost:${params.localPort}`,
+    );
+    return "reused";
+  }
+  if (inspection.state === "occupied") {
     throw new Error(
-      `Cannot start OpenCode tunnel: localhost:${params.localPort} is already in use (${usage ?? "unknown process"}).`,
+      `Cannot start OpenCode tunnel: localhost:${params.localPort} is already in use (${inspection.usage ?? "unknown process"}).`,
     );
   }
 
@@ -544,13 +875,79 @@ async function ensureBackgroundTunnel(params: {
 
   for (let attempt = 1; attempt <= 15; attempt += 1) {
     const usage = await getPortUsageSummary(params.localPort);
-    if (usage) return;
+    if (usage) return "started";
     await sleep(200);
   }
 
   throw new Error(
     `SSH tunnel command returned but localhost:${params.localPort} is not listening.`,
   );
+}
+
+async function readRemoteHostname(
+  remote: string,
+  sshOpts: string,
+): Promise<string | undefined> {
+  const sshArgs = shellSplit(sshOpts).map(expandTildeArg);
+  const result = await runCapture(["ssh", ...sshArgs, remote, "hostname"]);
+  if (result.code !== 0) return undefined;
+  const hostname = result.stdout.trim().split(/\s+/)[0];
+  return hostname || undefined;
+}
+
+function formatKnownTargetLine(params: {
+  target: KnownTarget;
+  status: "active" | "inactive" | "occupied";
+  usage?: string;
+}): string {
+  const vmName = params.target.remoteHost ?? params.target.remote;
+  const localUrl = `http://127.0.0.1:${params.target.opencodeLocalPort}`;
+  const parts = [
+    params.status,
+    `vm=${vmName}`,
+    `remote=${params.target.remote}`,
+    `repo=${params.target.repo}`,
+    `local=${localUrl}`,
+    `remote_port=${params.target.opencodeRemotePort}`,
+  ];
+  if (params.usage) {
+    parts.push(`usage=${JSON.stringify(params.usage)}`);
+  }
+  return parts.join(" ");
+}
+
+async function listKnownTargets(config: CodeboxConfig): Promise<string[]> {
+  const targets = getKnownTargetEntries(config)
+    .map(([, target]) => target)
+    .sort((left, right) => {
+      const a = left.updatedAt ?? left.lastTunneledAt ?? left.lastSyncedAt ?? "";
+      const b = right.updatedAt ?? right.lastTunneledAt ?? right.lastSyncedAt ?? "";
+      return b.localeCompare(a);
+    });
+  const lines: string[] = [];
+  for (const target of targets) {
+    const inspection = await inspectTunnelPort({
+      remote: target.remote,
+      localPort: target.opencodeLocalPort,
+      remotePort: target.opencodeRemotePort,
+    });
+    if (inspection.state === "expected") {
+      lines.push(formatKnownTargetLine({ target, status: "active" }));
+      continue;
+    }
+    if (inspection.state === "occupied") {
+      lines.push(
+        formatKnownTargetLine({
+          target,
+          status: "occupied",
+          usage: inspection.usage,
+        }),
+      );
+      continue;
+    }
+    lines.push(formatKnownTargetLine({ target, status: "inactive" }));
+  }
+  return lines;
 }
 
 function rsyncCmd(
@@ -603,14 +1000,158 @@ async function main() {
     process.env.CODEBOX_CONFIG ??
     expandHome("~/.config/codebox.json");
   const existingConfig = readConfig(configPath);
+  const tunnelListMode = mode === "tunnel" && hasFlag(args, "--list");
+  const tunnelAllMode = mode === "tunnel" && hasFlag(args, "--all");
+  const requestedRepo = mode === "tunnel" ? argValue(args, "--repo") : undefined;
+  if (tunnelListMode && tunnelAllMode) {
+    throw new Error("Cannot combine --list and --all in tunnel mode.");
+  }
+
+  const requestedBase = argValue(args, "--base") ?? process.env.BASE;
+  const requestedRemoteHint =
+    argValue(args, "--remote") ?? positionalRemote ?? process.env.REMOTE;
+  const rememberedTarget =
+    requestedRepo && !tunnelListMode && !tunnelAllMode
+      ? (() => {
+          const matches = selectKnownTargets(existingConfig, {
+            repo: requestedRepo,
+            remote: requestedRemoteHint,
+            base: requestedBase,
+          });
+          if (matches.length === 0) {
+            throw new Error(`No remembered target found for repo "${requestedRepo}".`);
+          }
+          if (matches.length > 1) {
+            throw new Error(
+              `Multiple remembered targets found for repo "${requestedRepo}". Pass --remote to disambiguate.`,
+            );
+          }
+          return matches[0];
+        })()
+      : undefined;
+
+  const sshOpts =
+    argValue(args, "--ssh-opts") ??
+    rememberedTarget?.sshOpts ??
+    process.env.SSH_OPTS ??
+    "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes";
+
+  const assumeYes = hasFlag(args, "--yes");
+  const verbose = hasFlag(args, "--verbose") || hasFlag(args, "-v");
+
+  const base =
+    requestedBase ??
+    rememberedTarget?.base ??
+    process.env.BASE ??
+    (typeof existingConfig.last_base === "string" ? existingConfig.last_base : undefined) ??
+    "$HOME/workspace";
+  const repoRoot = resolve(process.cwd());
+  const repoName = rememberedTarget?.repo ?? basename(repoRoot);
+  const remoteRepo = rememberedTarget?.remoteRepo ?? `${base}/${repoName}`;
 
   if (mode === "sync") {
     positionalRemote = undefined;
   }
+
+  if (tunnelListMode) {
+    const listedConfig = requestedRepo
+      ? {
+          ...existingConfig,
+          known_targets: Object.fromEntries(
+            getKnownTargetEntries(existingConfig).filter(([, target]) => target.repo === requestedRepo),
+          ),
+        }
+      : existingConfig;
+    const lines = await listKnownTargets(listedConfig);
+    if (lines.length === 0) {
+      console.log("[codebox] No remembered OpenCode tunnel targets.");
+      return;
+    }
+    for (const line of lines) {
+      console.log(line);
+    }
+    return;
+  }
+
+  if (tunnelAllMode) {
+    const rememberedTargets = selectKnownTargets(existingConfig, {
+      repo: requestedRepo,
+    });
+    if (rememberedTargets.length === 0) {
+      console.log("[codebox] No remembered OpenCode tunnel targets.");
+      return;
+    }
+
+    let nextConfig = existingConfig;
+    for (const rememberedTarget of rememberedTargets) {
+      const rememberedSshOpts = rememberedTarget.sshOpts ?? sshOpts;
+      const resolvedLocalPort = await resolveTunnelLocalPort({
+        config: nextConfig,
+        remote: rememberedTarget.remote,
+        base: rememberedTarget.base,
+        repo: rememberedTarget.repo,
+        localPort: rememberedTarget.opencodeLocalPort,
+        localPortExplicit: false,
+        remotePort: rememberedTarget.opencodeRemotePort,
+      });
+      const resolvedTarget: KnownTarget = {
+        ...rememberedTarget,
+        sshOpts: rememberedSshOpts,
+        opencodeLocalPort: resolvedLocalPort,
+      };
+      const tunnelCmd = buildTunnelCommand({
+        remote: resolvedTarget.remote,
+        sshOpts: rememberedSshOpts,
+        localPort: resolvedLocalPort,
+        remotePort: resolvedTarget.opencodeRemotePort,
+      });
+      if (hasFlag(args, "--dry-run")) {
+        console.log(`[dry-run] ${tunnelCmd.join(" ")}`);
+        continue;
+      }
+
+      const tunnelStatus = await ensureBackgroundTunnel({
+        remote: resolvedTarget.remote,
+        sshOpts: rememberedSshOpts,
+        localPort: resolvedLocalPort,
+        remotePort: resolvedTarget.opencodeRemotePort,
+      });
+      const updatedAt = new Date().toISOString();
+      const remoteHost =
+        resolvedTarget.remoteHost ??
+        (await readRemoteHostname(resolvedTarget.remote, rememberedSshOpts));
+      nextConfig = upsertKnownTarget(
+        nextConfig,
+        {
+          ...resolvedTarget,
+          remoteHost,
+          lastTunneledAt: updatedAt,
+        },
+        updatedAt,
+      );
+      console.log(
+        `[codebox] Tunnel ${tunnelStatus}: ${formatKnownTargetLine({
+          target: {
+            ...resolvedTarget,
+            remoteHost,
+            lastTunneledAt: updatedAt,
+          },
+          status: "active",
+        })}`,
+      );
+    }
+
+    if (!hasFlag(args, "--dry-run")) {
+      writeConfig(configPath, nextConfig);
+    }
+    return;
+  }
+
   const remote =
     argValue(args, "--remote") ??
     positionalRemote ??
     process.env.REMOTE ??
+    rememberedTarget?.remote ??
     (typeof existingConfig.last_remote === "string" ? existingConfig.last_remote : undefined);
   if (!remote) {
     console.error("Missing --remote");
@@ -619,25 +1160,19 @@ async function main() {
   }
   validateRemote(remote);
 
-  const sshOpts =
-    argValue(args, "--ssh-opts") ??
-    process.env.SSH_OPTS ??
-    "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes";
-
-  const assumeYes = hasFlag(args, "--yes");
-  const verbose = hasFlag(args, "--verbose") || hasFlag(args, "-v");
-
-  const base =
-    argValue(args, "--base") ??
-    process.env.BASE ??
-    (typeof existingConfig.last_base === "string" ? existingConfig.last_base : undefined) ??
-    "$HOME/workspace";
   const opencodeSrcArg = argValue(args, "--opencode-src") ?? process.env.OPENCODE_SRC;
   const opencodeSrcDefault = resolve(expandHome("~/workspace/opencode"));
   const opencodeSrc =
     opencodeSrcArg ?? (existsSync(opencodeSrcDefault) ? opencodeSrcDefault : undefined);
-  const opencodeLocalPort = parsePort(
-    argValue(args, "--opencode-local-port") ?? process.env.OPENCODE_LOCAL_PORT,
+  const opencodeRepoUrl =
+    argValue(args, "--opencode-repo-url") ??
+    process.env.OPENCODE_REPO_URL ??
+    DEFAULT_OPENCODE_REPO_URL;
+  const opencodeLocalPortRaw =
+    argValue(args, "--opencode-local-port") ?? process.env.OPENCODE_LOCAL_PORT;
+  const opencodeLocalPortExplicit = opencodeLocalPortRaw != null;
+  const parsedOpencodeLocalPort = parsePort(
+    opencodeLocalPortRaw,
     "--opencode-local-port",
     5551,
   );
@@ -646,18 +1181,48 @@ async function main() {
     "--opencode-remote-port",
     5551,
   );
+  const opencodeSupervisor = parseOpencodeSupervisor(
+    argValue(args, "--opencode-supervisor") ?? process.env.OPENCODE_SUPERVISOR,
+  );
+  const syncOpencodeConfig = !hasFlag(args, "--no-opencode-config");
+  const syncOpencodeAuth = syncOpencodeConfig && !hasFlag(args, "--no-opencode-auth");
+  const preferredOpencodeLocalPort = choosePreferredTunnelLocalPort({
+    config: existingConfig,
+    remote,
+    base,
+    repo: repoName,
+    remotePort: opencodeRemotePort,
+    explicitLocalPort: opencodeLocalPortExplicit ? parsedOpencodeLocalPort : undefined,
+    fallbackLocalPort: parsedOpencodeLocalPort,
+  });
+  const shouldResolveActivePort = mode === "tunnel" || !hasFlag(args, "--no-opencode-tunnel");
+  const resolvedOpencodeLocalPort = shouldResolveActivePort
+    ? await resolveTunnelLocalPort({
+        config: existingConfig,
+        remote,
+        base,
+        repo: repoName,
+        localPort: preferredOpencodeLocalPort,
+        localPortExplicit: opencodeLocalPortExplicit,
+        remotePort: opencodeRemotePort,
+      })
+    : preferredOpencodeLocalPort;
 
   const opts: Options = {
     remote,
     sshOpts,
     base,
     opencodeSrc,
+    opencodeRepoUrl,
+    repoExcludes: argValues(args, "--exclude"),
     opencodeTunnel: !hasFlag(args, "--no-opencode-tunnel"),
-    opencodeLocalPort,
+    opencodeLocalPort: resolvedOpencodeLocalPort,
     opencodeRemotePort,
+    opencodeSupervisor,
     syncGit: !hasFlag(args, "--no-git"),
     syncCodexConfig: !hasFlag(args, "--no-codex-config"),
-    syncOpencodeConfig: !hasFlag(args, "--no-opencode-config"),
+    syncOpencodeConfig,
+    syncOpencodeAuth,
     syncGhConfig: !hasFlag(args, "--no-gh-config"),
     syncSshKeys: hasFlag(args, "--sync-ssh"),
     includeCodexHistory: hasFlag(args, "--include-codex-history"),
@@ -676,9 +1241,21 @@ async function main() {
     );
   }
 
-  const repoRoot = resolve(process.cwd());
-  const repoName = basename(repoRoot);
-  const remoteRepo = `${opts.base}/${repoName}`;
+  const syncLocalOpencodeRepo = Boolean(opts.opencodeSrc && existsSync(opts.opencodeSrc));
+
+  if (mode === "sync" && syncLocalOpencodeRepo) {
+    const localOriginUrl = await readGitRemoteUrl(opts.opencodeSrc!, "origin");
+    if (!localOriginUrl) {
+      throw new Error(
+        `Local OpenCode repo at ${opts.opencodeSrc} must be a git checkout with origin ${opts.opencodeRepoUrl}.`,
+      );
+    }
+    if (canonicalGitRemoteUrl(localOriginUrl) !== canonicalGitRemoteUrl(opts.opencodeRepoUrl)) {
+      throw new Error(
+        `Local OpenCode repo origin (${localOriginUrl}) does not match required fork (${opts.opencodeRepoUrl}).`,
+      );
+    }
+  }
 
   if (mode === "ssh") {
     const remoteTarget = `${opts.base}/${repoName}`;
@@ -735,22 +1312,45 @@ async function main() {
       return;
     }
 
-    writeConfig(opts.configPath, {
-      ...existingConfig,
-      last_remote: opts.remote,
-      last_base: opts.base,
-      last_repo: repoName,
-      updated_at: new Date().toISOString(),
-    });
-
-    await ensureBackgroundTunnel({
+    const tunnelStatus = await ensureBackgroundTunnel({
       remote: opts.remote,
       sshOpts: opts.sshOpts,
       localPort: opts.opencodeLocalPort,
       remotePort: opts.opencodeRemotePort,
     });
+    const updatedAt = new Date().toISOString();
+    const remoteHost = await readRemoteHostname(opts.remote, opts.sshOpts);
+    const nextConfig = upsertKnownTarget(
+      existingConfig,
+      {
+        remote: opts.remote,
+        remoteHost,
+        sshOpts: opts.sshOpts,
+        base: opts.base,
+        repo: repoName,
+        remoteRepo,
+        opencodeLocalPort: opts.opencodeLocalPort,
+        opencodeRemotePort: opts.opencodeRemotePort,
+        lastTunneledAt: updatedAt,
+      },
+      updatedAt,
+    );
+    writeConfig(opts.configPath, nextConfig);
     console.log(
-      `[codebox] Tunnel ready: http://127.0.0.1:${opts.opencodeLocalPort} -> ${opts.remote}:127.0.0.1:${opts.opencodeRemotePort}`,
+      `[codebox] Tunnel ${tunnelStatus}: ${formatKnownTargetLine({
+        target: {
+          remote: opts.remote,
+          remoteHost,
+          sshOpts: opts.sshOpts,
+          base: opts.base,
+          repo: repoName,
+          remoteRepo,
+          opencodeLocalPort: opts.opencodeLocalPort,
+          opencodeRemotePort: opts.opencodeRemotePort,
+          lastTunneledAt: updatedAt,
+        },
+        status: "active",
+      })}`,
     );
     return;
   }
@@ -760,6 +1360,7 @@ async function main() {
     "node_modules",
     "dist",
     ".venv",
+    ...opts.repoExcludes,
   ];
   if (!opts.syncGit) {
     repoExcludes.unshift(".git");
@@ -778,12 +1379,12 @@ async function main() {
     ),
   });
 
-  if (opts.opencodeSrc && existsSync(opts.opencodeSrc)) {
+  if (syncLocalOpencodeRepo) {
     actions.push({
       label: "sync opencode repo",
       cmd: rsyncCmd(
         opts.sshOpts,
-        `${opts.opencodeSrc}/`,
+        `${opts.opencodeSrc!}/`,
         `${opts.remote}:${opts.base}/opencode/`,
         [".git", "node_modules", "dist", ".venv"],
         opts.verbose,
@@ -811,6 +1412,7 @@ async function main() {
   if (opts.syncOpencodeConfig) {
     const opencodeConfig = resolve(os.homedir(), ".config/opencode");
     const opencodeHome = resolve(os.homedir(), ".opencode");
+    const opencodeData = resolve(os.homedir(), ".local/share/opencode");
     if (existsSync(opencodeConfig)) {
       actions.push({
         label: "sync ~/.config/opencode",
@@ -834,6 +1436,22 @@ async function main() {
           opts.verbose,
         ),
       });
+    }
+    if (opts.syncOpencodeAuth && existsSync(opencodeData)) {
+      for (const authFile of ["auth.json", "mcp-auth.json"]) {
+        const source = resolve(opencodeData, authFile);
+        if (!existsSync(source)) continue;
+        actions.push({
+          label: `sync ~/.local/share/opencode/${authFile}`,
+          cmd: rsyncCmd(
+            opts.sshOpts,
+            source,
+            `${opts.remote}:~/.local/share/opencode/${authFile}`,
+            [],
+            opts.verbose,
+          ),
+        });
+      }
     }
   }
 
@@ -872,7 +1490,7 @@ async function main() {
       const shown = envKeys.slice(0, 10);
       const suffix = envKeys.length > 10 ? ` (+${envKeys.length - 10} more)` : "";
       await promptYes(
-        `About to sync ${envKeys.length} env vars to remote ~/.bashrc: ${shown.join(", ")}${suffix}.`,
+        `About to sync ${envKeys.length} env vars into remote shell/OpenCode env: ${shown.join(", ")}${suffix}.`,
         opts.assumeYes,
       );
     }
@@ -888,12 +1506,22 @@ async function main() {
   const envLines = Object.entries(opts.envVars)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([k, v]) => `export ${k}=${bashQuote(v)}`);
-  const envBlock = envLines.length
-    ? `# >>> codebox env >>>\n${envLines.join("\n")}\n# <<< codebox env <<<\n`
-    : "";
-  const envDelimiter = `CODEBOX_ENV_${Math.random().toString(36).slice(2)}`;
-  const envSetup = envBlock
-    ? `BASHRC="$HOME/.bashrc"
+  const envScript = envLines.length ? `${envLines.join("\n")}\n` : "";
+  const envScriptDelimiter = `CODEBOX_ENV_FILE_${Math.random().toString(36).slice(2)}`;
+  const envBashrcDelimiter = `CODEBOX_ENV_BASHRC_${Math.random().toString(36).slice(2)}`;
+  const envBashrcBlock = `# >>> codebox env >>>\nif [ -f "$HOME/.config/codebox/env.sh" ]; then\n  . "$HOME/.config/codebox/env.sh"\nfi\n# <<< codebox env <<<\n`;
+  const envSetup = opts.syncEnv
+    ? `mkdir -p "$HOME/.config/codebox"
+ENV_SCRIPT="$HOME/.config/codebox/env.sh"
+if [ ${envLines.length} -gt 0 ]; then
+  cat > "$ENV_SCRIPT" <<'${envScriptDelimiter}'
+${envScript}${envScriptDelimiter}
+  chmod 600 "$ENV_SCRIPT"
+else
+  rm -f "$ENV_SCRIPT"
+fi
+
+BASHRC="$HOME/.bashrc"
 TMP_BASHRC="$(mktemp)"
 if [ -f "$BASHRC" ]; then
   awk 'BEGIN{skip=0}
@@ -903,8 +1531,10 @@ if [ -f "$BASHRC" ]; then
 else
   : > "$TMP_BASHRC"
 fi
-cat >> "$TMP_BASHRC" <<'${envDelimiter}'
-${envBlock}${envDelimiter}
+if [ ${envLines.length} -gt 0 ]; then
+  cat >> "$TMP_BASHRC" <<'${envBashrcDelimiter}'
+${envBashrcBlock}${envBashrcDelimiter}
+fi
 mv "$TMP_BASHRC" "$BASHRC"
 
 `
@@ -924,7 +1554,9 @@ esac
 REPO_NAME=${bashQuote(repoName)}
 REPO_DIR="$REMOTE_BASE/$REPO_NAME"
 OPENCODE_DIR="$REMOTE_BASE/opencode"
+OPENCODE_REPO_URL=${bashQuote(opts.opencodeRepoUrl)}
 OPENCODE_PORT=${bashQuote(String(opts.opencodeRemotePort))}
+OPENCODE_SUPERVISOR=${bashQuote(opts.opencodeSupervisor)}
 
 is_port_listening() {
   if command -v lsof >/dev/null 2>&1; then
@@ -942,11 +1574,194 @@ is_port_listening() {
   return 1
 }
 
+SYSTEMD_RUN_DIR="/run/user/$(id -u)"
+systemd_user_cmd() {
+  env XDG_RUNTIME_DIR="$SYSTEMD_RUN_DIR" DBUS_SESSION_BUS_ADDRESS="unix:path=$SYSTEMD_RUN_DIR/bus" systemctl --user "$@"
+}
+
+systemd_user_available() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  [ -d "$SYSTEMD_RUN_DIR" ] || return 1
+  systemd_user_cmd show-environment >/dev/null 2>&1
+}
+
+ensure_linger_enabled() {
+  command -v loginctl >/dev/null 2>&1 || return 0
+  if loginctl show-user "$USER" -p Linger 2>/dev/null | grep -q '=yes$'; then
+    return 0
+  fi
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    if sudo loginctl enable-linger "$USER" >/dev/null 2>&1; then
+      echo "Info: enabled lingering for $USER so user services survive logout"
+      return 0
+    fi
+  fi
+  echo "Warning: systemd user lingering is not enabled for $USER; OpenCode may stop after logout."
+}
+
+resolve_opencode_bin() {
+  if [ -x "$HOME/.local/bin/opencode" ]; then
+    printf '%s\\n' "$HOME/.local/bin/opencode"
+    return 0
+  fi
+  if [ -x "$HOME/.opencode/bin/opencode" ]; then
+    printf '%s\\n' "$HOME/.opencode/bin/opencode"
+    return 0
+  fi
+  if command -v opencode >/dev/null 2>&1; then
+    command -v opencode
+    return 0
+  fi
+  return 1
+}
+
+ensure_opencode_checkout() {
+  if ! command -v git >/dev/null 2>&1; then
+    echo "Error: git is required on the remote host to manage the OpenCode checkout." >&2
+    return 1
+  fi
+
+  if [ -d "$OPENCODE_DIR/.git" ] && git -C "$OPENCODE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git -C "$OPENCODE_DIR" remote get-url origin >/dev/null 2>&1; then
+      git -C "$OPENCODE_DIR" remote set-url origin "$OPENCODE_REPO_URL"
+    else
+      git -C "$OPENCODE_DIR" remote add origin "$OPENCODE_REPO_URL"
+    fi
+    return 0
+  fi
+
+  local scratch_dir
+  scratch_dir="$(mktemp -d "$REMOTE_BASE/.codebox-opencode.XXXXXX")"
+  git clone "$OPENCODE_REPO_URL" "$scratch_dir/repo"
+  if [ -d "$OPENCODE_DIR" ] && [ -n "$(ls -A "$OPENCODE_DIR" 2>/dev/null)" ]; then
+    rsync -a --delete --exclude .git "$OPENCODE_DIR"/ "$scratch_dir/repo"/
+  fi
+  rm -rf "$OPENCODE_DIR"
+  mv "$scratch_dir/repo" "$OPENCODE_DIR"
+  rmdir "$scratch_dir" 2>/dev/null || true
+  echo "Info: ensured OpenCode checkout at $OPENCODE_DIR from $OPENCODE_REPO_URL"
+}
+
+stop_opencode_runtime() {
+  if systemd_user_available && [ -f "$HOME/.config/systemd/user/opencode-serve.service" ]; then
+    systemd_user_cmd stop opencode-serve.service >/dev/null 2>&1 || true
+  fi
+  pkill -f "opencode serve --hostname 127.0.0.1 --port $OPENCODE_PORT" >/dev/null 2>&1 || true
+  for _ in $(seq 1 15); do
+    if ! is_port_listening "$OPENCODE_PORT"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Warning: timed out waiting for OpenCode to stop on 127.0.0.1:$OPENCODE_PORT"
+}
+
+install_opencode_local() {
+  local attempted=0
+  local runtime_stopped=0
+
+  prepare_install_runtime() {
+    if [ "$runtime_stopped" -eq 1 ]; then
+      return 0
+    fi
+    stop_opencode_runtime
+    runtime_stopped=1
+    if [ ! -d "$OPENCODE_DIR/.git" ]; then
+      export OPENCODE_CHANNEL="\${OPENCODE_CHANNEL:-latest}"
+    fi
+  }
+
+  if [ -x "./scripts/install-local.sh" ]; then
+    attempted=1
+    if grep -qE '^(<<<<<<< |=======|>>>>>>> )' ./scripts/install-local.sh; then
+      echo "Warning: skipping ./scripts/install-local.sh due to merge-conflict markers; trying Bun install hooks if available."
+    else
+      prepare_install_runtime
+      if devbox run -- bash -lc "./scripts/install-local.sh"; then
+        return 0
+      fi
+      echo "Warning: ./scripts/install-local.sh failed; trying Bun install hooks if available."
+    fi
+  fi
+
+  if [ -f "./package.json" ] && grep -q '"install:local"' ./package.json; then
+    attempted=1
+    prepare_install_runtime
+    if devbox run -- bash -lc "bun run install:local"; then
+      return 0
+    fi
+    echo "Warning: bun run install:local failed; trying package-level install hook if available."
+  fi
+
+  if [ -f "./packages/opencode/package.json" ] && grep -q '"install:local"' ./packages/opencode/package.json; then
+    attempted=1
+    prepare_install_runtime
+    if devbox run -- bash -lc "bun run --cwd packages/opencode install:local"; then
+      return 0
+    fi
+    echo "Warning: bun run --cwd packages/opencode install:local failed; continuing bootstrap."
+  fi
+
+  if [ "$attempted" -eq 0 ]; then
+    echo "Info: skipping local OpenCode install; no install hook found in $OPENCODE_DIR"
+    return 0
+  fi
+
+  return 1
+}
+
+start_opencode_nohup() {
+  if is_port_listening "$OPENCODE_PORT"; then
+    echo "Info: OpenCode already listening on 127.0.0.1:$OPENCODE_PORT"
+    return 0
+  fi
+  mkdir -p "$HOME/.cache/codebox"
+  nohup "$OPENCODE_BIN" serve --hostname 127.0.0.1 --port "$OPENCODE_PORT" \
+    > "$HOME/.cache/codebox/opencode-serve.log" 2>&1 &
+  echo "Info: started OpenCode serve via nohup on 127.0.0.1:$OPENCODE_PORT (log: ~/.cache/codebox/opencode-serve.log)"
+}
+
+write_opencode_systemd_unit() {
+  mkdir -p "$HOME/.config/systemd/user" "$HOME/.cache/codebox"
+  cat > "$HOME/.config/systemd/user/opencode-serve.service" <<EOF
+[Unit]
+Description=OpenCode headless server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$REMOTE_BASE
+ExecStart=/bin/bash -lc 'if [ -f "$HOME/.config/codebox/env.sh" ]; then . "$HOME/.config/codebox/env.sh"; fi; if [ -x "$HOME/.local/bin/opencode" ]; then OPENCODE_BIN="$HOME/.local/bin/opencode"; elif [ -x "$HOME/.opencode/bin/opencode" ]; then OPENCODE_BIN="$HOME/.opencode/bin/opencode"; else OPENCODE_BIN="$(command -v opencode)"; fi; exec "\\$OPENCODE_BIN" serve --hostname 127.0.0.1 --port ${opts.opencodeRemotePort}'
+Restart=always
+RestartSec=2
+StandardOutput=append:%h/.cache/codebox/opencode-serve.log
+StandardError=append:%h/.cache/codebox/opencode-serve.log
+
+[Install]
+WantedBy=default.target
+EOF
+}
+
+start_opencode_systemd() {
+  if ! systemd_user_available; then
+    return 1
+  fi
+  ensure_linger_enabled
+  write_opencode_systemd_unit
+  systemd_user_cmd daemon-reload
+  systemd_user_cmd enable --now opencode-serve.service >/dev/null
+  systemd_user_cmd restart opencode-serve.service >/dev/null
+  echo "Info: ensured OpenCode systemd user service opencode-serve.service"
+}
+
 ${envSetup}if ! command -v devbox >/dev/null 2>&1; then
   curl -fsSL https://get.jetpack.io/devbox | bash -s -- -f
 fi
 
-mkdir -p "$REPO_DIR" "$OPENCODE_DIR" ~/.config/opencode ~/.opencode ~/.codex ~/.config/gh ~/.local/bin
+mkdir -p "$REPO_DIR" "$OPENCODE_DIR" ~/.config/opencode ~/.opencode ~/.codex ~/.config/gh ~/.local/bin ~/.local/share/opencode
+
+ensure_opencode_checkout
 
 cat > "$REPO_DIR/devbox.json" <<'EOF'
 ${devboxCodexJson}
@@ -968,26 +1783,33 @@ fi
 if [ -d "$OPENCODE_DIR" ]; then
   cd "$OPENCODE_DIR"
   devbox install
-  if [ -x "./scripts/install-local.sh" ]; then
-    if grep -qE '^(<<<<<<< |=======|>>>>>>> )' ./scripts/install-local.sh; then
-      echo "Warning: skipping ./scripts/install-local.sh due to merge-conflict markers."
-    else
-      if ! devbox run -- bash -lc "./scripts/install-local.sh"; then
-        echo "Warning: ./scripts/install-local.sh failed; continuing bootstrap."
-      fi
-    fi
+  if ! install_opencode_local; then
+    echo "Warning: OpenCode local install failed; continuing bootstrap."
   fi
 fi
 
-if command -v opencode >/dev/null 2>&1; then
-  if is_port_listening "$OPENCODE_PORT"; then
-    echo "Info: OpenCode already listening on 127.0.0.1:$OPENCODE_PORT"
-  else
-    mkdir -p "$HOME/.cache/codebox"
-    nohup opencode serve --hostname 127.0.0.1 --port "$OPENCODE_PORT" \
-      > "$HOME/.cache/codebox/opencode-serve.log" 2>&1 &
-    echo "Info: started OpenCode serve on 127.0.0.1:$OPENCODE_PORT (log: ~/.cache/codebox/opencode-serve.log)"
-  fi
+OPENCODE_BIN=""
+if OPENCODE_BIN="$(resolve_opencode_bin)"; then
+  case "$OPENCODE_SUPERVISOR" in
+    systemd)
+      if ! start_opencode_systemd; then
+        echo "Warning: requested systemd supervision for OpenCode, but systemd user services are unavailable; falling back to nohup."
+        start_opencode_nohup
+      fi
+      ;;
+    auto)
+      if ! start_opencode_systemd; then
+        start_opencode_nohup
+      fi
+      ;;
+    nohup)
+      start_opencode_nohup
+      ;;
+    *)
+      echo "Warning: unknown OpenCode supervisor '$OPENCODE_SUPERVISOR'; falling back to nohup."
+      start_opencode_nohup
+      ;;
+  esac
 
   for _ in $(seq 1 25); do
     if is_port_listening "$OPENCODE_PORT"; then
@@ -1021,32 +1843,82 @@ fi
     return;
   }
 
-  writeConfig(opts.configPath, {
-    ...existingConfig,
-    last_remote: opts.remote,
-    last_base: opts.base,
-    last_repo: repoName,
-    updated_at: new Date().toISOString(),
+  const baseSetupScript = `#!/usr/bin/env bash
+set -euo pipefail
+BASE_INPUT=${bashQuote(opts.base)}
+case "$BASE_INPUT" in
+  '$HOME') REMOTE_BASE="$HOME" ;;
+  '$HOME'/*) REMOTE_BASE="$HOME/\${BASE_INPUT:6}" ;;
+  "~") REMOTE_BASE="$HOME" ;;
+  "~/"*) REMOTE_BASE="$HOME/\${BASE_INPUT#~/}" ;;
+  *) REMOTE_BASE="$BASE_INPUT" ;;
+esac
+mkdir -p "$REMOTE_BASE" "$REMOTE_BASE/opencode"
+mkdir -p "$HOME/.local/share/opencode" "$HOME/.config/codebox"
+`;
+  const encoder = new TextEncoder();
+  const sshArgs = shellSplit(opts.sshOpts).map(expandTildeArg);
+  await run(["ssh", ...sshArgs, opts.remote, "bash", "-s"], {
+    stdin: encoder.encode(baseSetupScript),
   });
 
   for (const a of actions) {
     await run(a.cmd);
   }
 
-  const encoder = new TextEncoder();
-  const sshArgs = shellSplit(opts.sshOpts).map(expandTildeArg);
   const sshCmd = ["ssh", ...sshArgs, opts.remote, "bash", "-s"];
   await run(sshCmd, { stdin: encoder.encode(remoteScript) });
 
+  let tunnelStatus: "reused" | "started" | undefined;
   if (opts.opencodeTunnel) {
-    await ensureBackgroundTunnel({
+    tunnelStatus = await ensureBackgroundTunnel({
       remote: opts.remote,
       sshOpts: opts.sshOpts,
       localPort: opts.opencodeLocalPort,
       remotePort: opts.opencodeRemotePort,
     });
+  }
+
+  const currentKnownTarget = findKnownTarget(existingConfig, opts.remote, opts.base, repoName)?.target;
+  const updatedAt = new Date().toISOString();
+  const remoteHost = await readRemoteHostname(opts.remote, opts.sshOpts);
+  const nextConfig = upsertKnownTarget(
+    existingConfig,
+    {
+      remote: opts.remote,
+      remoteHost,
+      sshOpts: opts.sshOpts,
+      base: opts.base,
+      repo: repoName,
+      remoteRepo,
+      opencodeLocalPort: opts.opencodeLocalPort,
+      opencodeRemotePort: opts.opencodeRemotePort,
+      lastSyncedAt: updatedAt,
+      lastTunneledAt: opts.opencodeTunnel
+        ? updatedAt
+        : currentKnownTarget?.lastTunneledAt,
+    },
+    updatedAt,
+  );
+  writeConfig(opts.configPath, nextConfig);
+
+  if (opts.opencodeTunnel) {
     console.log(
-      `[codebox] OpenCode tunnel ready: http://127.0.0.1:${opts.opencodeLocalPort} -> ${opts.remote}:127.0.0.1:${opts.opencodeRemotePort}`,
+      `[codebox] Tunnel ${tunnelStatus}: ${formatKnownTargetLine({
+        target: {
+          remote: opts.remote,
+          remoteHost,
+          sshOpts: opts.sshOpts,
+          base: opts.base,
+          repo: repoName,
+          remoteRepo,
+          opencodeLocalPort: opts.opencodeLocalPort,
+          opencodeRemotePort: opts.opencodeRemotePort,
+          lastSyncedAt: updatedAt,
+          lastTunneledAt: updatedAt,
+        },
+        status: "active",
+      })}`,
     );
   }
 }

--- a/codebox.ts
+++ b/codebox.ts
@@ -21,6 +21,7 @@ type Options = {
   opencodeLocalPort: number;
   opencodeRemotePort: number;
   opencodeSupervisor: OpencodeSupervisor;
+  syncRepo: boolean;
   syncGit: boolean;
   syncCodexConfig: boolean;
   syncOpencodeConfig: boolean;
@@ -30,6 +31,7 @@ type Options = {
   includeCodexHistory: boolean;
   syncEnv: boolean;
   envVars: Record<string, string>;
+  reinstallOpencode: boolean;
   assumeYes: boolean;
   verbose: boolean;
   dryRun: boolean;
@@ -85,6 +87,7 @@ Options:
   --list                      Tunnel mode only: show remembered tunnel targets
   --all                       Tunnel mode only: start/reconcile all remembered tunnel targets
   --no-git                    Do NOT sync .git (default: sync .git)
+  --no-repo                   Skip syncing the workspace repo entirely
   --no-codex-config           Skip syncing ~/.codex
   --no-opencode-config        Skip syncing ~/.config/opencode and ~/.opencode
   --no-opencode-auth          Skip syncing ~/.local/share/opencode auth state
@@ -94,6 +97,7 @@ Options:
   --no-env                    Do NOT sync env vars to the remote shell/OpenCode env
   --env <NAME>                Also sync a specific env var (repeatable)
   --env-prefix <PREFIX>       Sync env vars with this prefix (repeatable)
+  --reinstall-opencode        Force reinstall of OpenCode on the remote (stops service, re-runs install hooks)
   --yes                       Assume yes for prompts (env/ssh sync)
   -v, --verbose               Verbose rsync output (progress)
   --dry-run                   Print actions without executing
@@ -672,6 +676,7 @@ function parseSshModeArgs(rawArgs: string[]): ParsedSshModeArgs {
   const boolFlags = new Set([
     "--no-opencode-tunnel",
     "--no-git",
+    "--no-repo",
     "--no-codex-config",
     "--no-opencode-config",
     "--no-opencode-auth",
@@ -683,6 +688,7 @@ function parseSshModeArgs(rawArgs: string[]): ParsedSshModeArgs {
     "--verbose",
     "-v",
     "--dry-run",
+    "--reinstall-opencode",
   ]);
   const sshFlagsWithValue = new Set([
     "-B",
@@ -1334,6 +1340,7 @@ async function main() {
     opencodeLocalPort: resolvedOpencodeLocalPort,
     opencodeRemotePort,
     opencodeSupervisor,
+    syncRepo: !hasFlag(args, "--no-repo"),
     syncGit: !hasFlag(args, "--no-git"),
     syncCodexConfig: !hasFlag(args, "--no-codex-config"),
     syncOpencodeConfig,
@@ -1343,6 +1350,7 @@ async function main() {
     includeCodexHistory: hasFlag(args, "--include-codex-history"),
     syncEnv: !hasFlag(args, "--no-env"),
     envVars: {},
+    reinstallOpencode: hasFlag(args, "--reinstall-opencode"),
     assumeYes,
     verbose,
     dryRun: hasFlag(args, "--dry-run"),
@@ -1483,16 +1491,18 @@ async function main() {
 
   const actions: Array<{ label: string; cmd: string[]; stdin?: string }> = [];
 
-  actions.push({
-    label: "sync repo",
-    cmd: rsyncCmd(
-      opts.sshOpts,
-      `${repoRoot}/`,
-      `${opts.remote}:${remoteRepo}/`,
-      repoExcludes,
-      opts.verbose,
-    ),
-  });
+  if (opts.syncRepo) {
+    actions.push({
+      label: "sync repo",
+      cmd: rsyncCmd(
+        opts.sshOpts,
+        `${repoRoot}/`,
+        `${opts.remote}:${remoteRepo}/`,
+        repoExcludes,
+        opts.verbose,
+      ),
+    });
+  }
 
   if (syncLocalOpencodeRepo) {
     actions.push({
@@ -1674,6 +1684,7 @@ OPENCODE_REF=${bashQuote(opts.opencodeRef)}
 OPENCODE_SYNC_LOCAL_SOURCE=${bashQuote(syncLocalOpencodeRepo ? "1" : "0")}
 OPENCODE_PORT=${bashQuote(String(opts.opencodeRemotePort))}
 OPENCODE_SUPERVISOR=${bashQuote(opts.opencodeSupervisor)}
+OPENCODE_REINSTALL=${bashQuote(opts.reinstallOpencode ? "1" : "0")}
 
 is_port_listening() {
   if command -v lsof >/dev/null 2>&1; then
@@ -1914,7 +1925,6 @@ fi
 mkdir -p "$REPO_DIR" "$OPENCODE_DIR" ~/.config/opencode ~/.opencode ~/.codex ~/.config/gh ~/.local/bin ~/.local/share/opencode
 
 ensure_opencode_checkout
-
 cat > "$REPO_DIR/devbox.json" <<'EOF'
 ${devboxCodexJson}
 EOF
@@ -1935,7 +1945,11 @@ fi
 if [ -d "$OPENCODE_DIR" ]; then
   cd "$OPENCODE_DIR"
   devbox install
-  if ! install_opencode_local; then
+  if [ "$OPENCODE_REINSTALL" = "1" ]; then
+    if ! install_opencode_local; then
+      echo "Warning: OpenCode reinstall failed; continuing bootstrap."
+    fi
+  elif ! install_opencode_local; then
     echo "Warning: OpenCode local install failed; continuing bootstrap."
   fi
 fi

--- a/codebox.ts
+++ b/codebox.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 
 type OpencodeSupervisor = "auto" | "nohup" | "systemd";
 const DEFAULT_OPENCODE_REPO_URL = "https://github.com/dzianisv/opencode.git";
+const DEFAULT_OPENCODE_REF = "dev";
 
 type Options = {
   remote: string;
@@ -12,6 +13,7 @@ type Options = {
   base: string;
   opencodeSrc?: string;
   opencodeRepoUrl: string;
+  opencodeRef: string;
   repoExcludes: string[];
   opencodeTunnel: boolean;
   opencodeLocalPort: number;
@@ -70,8 +72,9 @@ Options:
   --ssh-opts <string>         SSH options (default: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes")
   --base <path>               Remote base dir (default: "$HOME/workspace")
   --repo <name>               Tunnel mode only: remembered repo to target instead of current working directory
-  --opencode-src <path>       Local opencode repo path (default: ~/workspace/opencode if exists)
+  --opencode-src <path>       Optional local opencode repo path to sync instead of managed remote checkout
   --opencode-repo-url <url>   OpenCode git remote to anchor on the target (default: "${DEFAULT_OPENCODE_REPO_URL}")
+  --opencode-ref <branch|sha> OpenCode branch or commit for the managed remote checkout (default: "${DEFAULT_OPENCODE_REF}")
   --exclude <pattern>         Extra repo rsync exclude pattern (repeatable)
   --no-opencode-tunnel        Skip auto-starting localhost SSH tunnel to remote OpenCode
   --opencode-local-port <n>   Local forwarded port (default: 5551)
@@ -98,6 +101,7 @@ SSH mode:
 
 Example:
   ./codebox.ts --remote azureuser@dev-1 --base '$HOME/workspace'
+  ./codebox.ts --remote azureuser@dev-1 --opencode-ref dev
   ./codebox.ts ssh azureuser@dev-1
   ./codebox.ts ssh -L 4097:127.0.0.1:4097 -N
   ./codebox.ts tunnel
@@ -128,6 +132,18 @@ function argValues(args: string[], name: string): string[] {
 
 function hasFlag(args: string[], name: string): boolean {
   return args.includes(name);
+}
+
+function parseNonEmptyOption(
+  value: string | undefined,
+  name: string,
+  fallback: string,
+): string {
+  const resolved = (value ?? fallback).trim();
+  if (!resolved) {
+    throw new Error(`${name} cannot be empty.`);
+  }
+  return resolved;
 }
 
 function expandHome(p: string): string {
@@ -498,6 +514,7 @@ function findPositionalRemote(args: string[]): string | undefined {
     "--repo",
     "--opencode-src",
     "--opencode-repo-url",
+    "--opencode-ref",
     "--opencode-local-port",
     "--opencode-remote-port",
     "--opencode-supervisor",
@@ -537,6 +554,7 @@ function parseSshModeArgs(rawArgs: string[]): ParsedSshModeArgs {
     "--repo",
     "--opencode-src",
     "--opencode-repo-url",
+    "--opencode-ref",
     "--opencode-local-port",
     "--opencode-remote-port",
     "--opencode-supervisor",
@@ -1161,13 +1179,16 @@ async function main() {
   validateRemote(remote);
 
   const opencodeSrcArg = argValue(args, "--opencode-src") ?? process.env.OPENCODE_SRC;
-  const opencodeSrcDefault = resolve(expandHome("~/workspace/opencode"));
-  const opencodeSrc =
-    opencodeSrcArg ?? (existsSync(opencodeSrcDefault) ? opencodeSrcDefault : undefined);
+  const opencodeSrc = opencodeSrcArg ? resolve(expandHome(opencodeSrcArg)) : undefined;
   const opencodeRepoUrl =
     argValue(args, "--opencode-repo-url") ??
     process.env.OPENCODE_REPO_URL ??
     DEFAULT_OPENCODE_REPO_URL;
+  const opencodeRef = parseNonEmptyOption(
+    argValue(args, "--opencode-ref") ?? process.env.OPENCODE_REF,
+    "--opencode-ref",
+    DEFAULT_OPENCODE_REF,
+  );
   const opencodeLocalPortRaw =
     argValue(args, "--opencode-local-port") ?? process.env.OPENCODE_LOCAL_PORT;
   const opencodeLocalPortExplicit = opencodeLocalPortRaw != null;
@@ -1214,6 +1235,7 @@ async function main() {
     base,
     opencodeSrc,
     opencodeRepoUrl,
+    opencodeRef,
     repoExcludes: argValues(args, "--exclude"),
     opencodeTunnel: !hasFlag(args, "--no-opencode-tunnel"),
     opencodeLocalPort: resolvedOpencodeLocalPort,
@@ -1555,6 +1577,8 @@ REPO_NAME=${bashQuote(repoName)}
 REPO_DIR="$REMOTE_BASE/$REPO_NAME"
 OPENCODE_DIR="$REMOTE_BASE/opencode"
 OPENCODE_REPO_URL=${bashQuote(opts.opencodeRepoUrl)}
+OPENCODE_REF=${bashQuote(opts.opencodeRef)}
+OPENCODE_SYNC_LOCAL_SOURCE=${bashQuote(syncLocalOpencodeRepo ? "1" : "0")}
 OPENCODE_PORT=${bashQuote(String(opts.opencodeRemotePort))}
 OPENCODE_SUPERVISOR=${bashQuote(opts.opencodeSupervisor)}
 
@@ -1627,19 +1651,47 @@ ensure_opencode_checkout() {
     else
       git -C "$OPENCODE_DIR" remote add origin "$OPENCODE_REPO_URL"
     fi
+    echo "Info: ensured OpenCode checkout at $OPENCODE_DIR from $OPENCODE_REPO_URL"
+  else
+    local scratch_dir
+    scratch_dir="$(mktemp -d "$REMOTE_BASE/.codebox-opencode.XXXXXX")"
+    git clone "$OPENCODE_REPO_URL" "$scratch_dir/repo"
+    if [ -d "$OPENCODE_DIR" ] && [ -n "$(ls -A "$OPENCODE_DIR" 2>/dev/null)" ]; then
+      rsync -a --delete --exclude .git "$OPENCODE_DIR"/ "$scratch_dir/repo"/
+    fi
+    rm -rf "$OPENCODE_DIR"
+    mv "$scratch_dir/repo" "$OPENCODE_DIR"
+    rmdir "$scratch_dir" 2>/dev/null || true
+    echo "Info: ensured OpenCode checkout at $OPENCODE_DIR from $OPENCODE_REPO_URL"
+  fi
+
+  if [ "$OPENCODE_SYNC_LOCAL_SOURCE" = "1" ]; then
+    echo "Info: preserving synced local OpenCode source at $OPENCODE_DIR (requested ref: $OPENCODE_REF)"
     return 0
   fi
 
-  local scratch_dir
-  scratch_dir="$(mktemp -d "$REMOTE_BASE/.codebox-opencode.XXXXXX")"
-  git clone "$OPENCODE_REPO_URL" "$scratch_dir/repo"
-  if [ -d "$OPENCODE_DIR" ] && [ -n "$(ls -A "$OPENCODE_DIR" 2>/dev/null)" ]; then
-    rsync -a --delete --exclude .git "$OPENCODE_DIR"/ "$scratch_dir/repo"/
+  git -C "$OPENCODE_DIR" fetch --force --tags --prune origin
+
+  if git -C "$OPENCODE_DIR" show-ref --verify --quiet "refs/remotes/origin/$OPENCODE_REF"; then
+    git -C "$OPENCODE_DIR" checkout -B "$OPENCODE_REF" "refs/remotes/origin/$OPENCODE_REF"
+    echo "Info: checked out OpenCode ref origin/$OPENCODE_REF"
+    return 0
   fi
-  rm -rf "$OPENCODE_DIR"
-  mv "$scratch_dir/repo" "$OPENCODE_DIR"
-  rmdir "$scratch_dir" 2>/dev/null || true
-  echo "Info: ensured OpenCode checkout at $OPENCODE_DIR from $OPENCODE_REPO_URL"
+
+  if git -C "$OPENCODE_DIR" rev-parse --verify --quiet "$OPENCODE_REF^{commit}" >/dev/null; then
+    git -C "$OPENCODE_DIR" checkout --detach "$OPENCODE_REF"
+    echo "Info: checked out OpenCode ref $OPENCODE_REF"
+    return 0
+  fi
+
+  if git -C "$OPENCODE_DIR" fetch --force origin "$OPENCODE_REF" >/dev/null 2>&1; then
+    git -C "$OPENCODE_DIR" checkout --detach FETCH_HEAD
+    echo "Info: checked out OpenCode fetched ref $OPENCODE_REF"
+    return 0
+  fi
+
+  echo "Error: failed to resolve OpenCode ref '$OPENCODE_REF' from $OPENCODE_REPO_URL." >&2
+  return 1
 }
 
 stop_opencode_runtime() {

--- a/codebox.ts
+++ b/codebox.ts
@@ -1716,8 +1716,15 @@ start_opencode_nohup() {
     return 0
   fi
   mkdir -p "$HOME/.cache/codebox"
-  nohup "$OPENCODE_BIN" serve --hostname 127.0.0.1 --port "$OPENCODE_PORT" \
-    > "$HOME/.cache/codebox/opencode-serve.log" 2>&1 &
+  if ! (
+    cd "$OPENCODE_DIR" &&
+    OPENCODE_DISABLE_CHANNEL_DB="\${OPENCODE_DISABLE_CHANNEL_DB:-1}" \
+    nohup "$OPENCODE_BIN" serve --hostname 127.0.0.1 --port "$OPENCODE_PORT" \
+      > "$HOME/.cache/codebox/opencode-serve.log" 2>&1 &
+  ); then
+    echo "Warning: failed to start OpenCode serve from $OPENCODE_DIR via nohup."
+    return 1
+  fi
   echo "Info: started OpenCode serve via nohup on 127.0.0.1:$OPENCODE_PORT (log: ~/.cache/codebox/opencode-serve.log)"
 }
 
@@ -1731,8 +1738,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=$REMOTE_BASE
-ExecStart=/bin/bash -lc 'if [ -f "$HOME/.config/codebox/env.sh" ]; then . "$HOME/.config/codebox/env.sh"; fi; if [ -x "$HOME/.local/bin/opencode" ]; then OPENCODE_BIN="$HOME/.local/bin/opencode"; elif [ -x "$HOME/.opencode/bin/opencode" ]; then OPENCODE_BIN="$HOME/.opencode/bin/opencode"; else OPENCODE_BIN="$(command -v opencode)"; fi; exec "\\$OPENCODE_BIN" serve --hostname 127.0.0.1 --port ${opts.opencodeRemotePort}'
+WorkingDirectory=$OPENCODE_DIR
+ExecStart=/bin/bash -lc 'if [ -f "$HOME/.config/codebox/env.sh" ]; then . "$HOME/.config/codebox/env.sh"; fi; if [ -x "$HOME/.local/bin/opencode" ]; then OPENCODE_BIN="$HOME/.local/bin/opencode"; elif [ -x "$HOME/.opencode/bin/opencode" ]; then OPENCODE_BIN="$HOME/.opencode/bin/opencode"; else OPENCODE_BIN="$(command -v opencode)"; fi; export OPENCODE_DISABLE_CHANNEL_DB="\${OPENCODE_DISABLE_CHANNEL_DB:-1}"; exec "\\$OPENCODE_BIN" serve --hostname 127.0.0.1 --port ${opts.opencodeRemotePort}'
 Restart=always
 RestartSec=2
 StandardOutput=append:%h/.cache/codebox/opencode-serve.log

--- a/codebox.ts
+++ b/codebox.ts
@@ -4,8 +4,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 
 type OpencodeSupervisor = "auto" | "nohup" | "systemd";
+const DEFAULT_BASE = "$HOME/workspace";
 const DEFAULT_OPENCODE_REPO_URL = "https://github.com/dzianisv/opencode.git";
 const DEFAULT_OPENCODE_REF = "dev";
+const DEFAULT_OPENCODE_SUPERVISOR: OpencodeSupervisor = "systemd";
 
 type Options = {
   remote: string;
@@ -63,14 +65,14 @@ type KnownTargetSelector = {
 
 function usage(): string {
   return `Usage:
-  ./codebox.ts --remote <user@host> [options]
+  ./codebox.ts [--remote <user@host>] [options]
   ./codebox.ts ssh [<user@host>] [options] [ssh-options] [-- <remote command...>]
   ./codebox.ts tunnel [<user@host>] [options]
 
 Options:
-  --remote <user@host>        SSH target (required for sync mode)
+  --remote <user@host>        SSH target (default: recent remembered target)
   --ssh-opts <string>         SSH options (default: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes")
-  --base <path>               Remote base dir (default: "$HOME/workspace")
+  --base <path>               Remote base dir (default: "${DEFAULT_BASE}")
   --repo <name>               Tunnel mode only: remembered repo to target instead of current working directory
   --opencode-src <path>       Optional local opencode repo path to sync instead of managed remote checkout
   --opencode-repo-url <url>   OpenCode git remote to anchor on the target (default: "${DEFAULT_OPENCODE_REPO_URL}")
@@ -79,7 +81,7 @@ Options:
   --no-opencode-tunnel        Skip auto-starting localhost SSH tunnel to remote OpenCode
   --opencode-local-port <n>   Local forwarded port (default: 5551)
   --opencode-remote-port <n>  Remote OpenCode port (default: 5551)
-  --opencode-supervisor <m>   Remote OpenCode supervisor: auto|nohup|systemd (default: auto)
+  --opencode-supervisor <m>   Remote OpenCode supervisor: auto|nohup|systemd (default: ${DEFAULT_OPENCODE_SUPERVISOR})
   --list                      Tunnel mode only: show remembered tunnel targets
   --all                       Tunnel mode only: start/reconcile all remembered tunnel targets
   --no-git                    Do NOT sync .git (default: sync .git)
@@ -100,9 +102,10 @@ SSH mode:
   Unrecognized ssh-mode flags are passed through to ssh (for example: -L, -R, -D, -N, -p, -i).
 
 Example:
-  ./codebox.ts --remote azureuser@dev-1 --base '$HOME/workspace'
+  ./codebox.ts --remote azureuser@dev-1
   ./codebox.ts --remote azureuser@dev-1 --opencode-ref dev
   ./codebox.ts ssh azureuser@dev-1
+  ./codebox.ts ssh
   ./codebox.ts ssh -L 4097:127.0.0.1:4097 -N
   ./codebox.ts tunnel
   ./codebox.ts tunnel azureuser@dev-1 --opencode-local-port 4097 --opencode-remote-port 4097
@@ -256,10 +259,111 @@ function selectKnownTargets(
       return true;
     })
     .sort((left, right) => {
-      const a = left.updatedAt ?? left.lastTunneledAt ?? left.lastSyncedAt ?? "";
-      const b = right.updatedAt ?? right.lastTunneledAt ?? right.lastSyncedAt ?? "";
+      const a = knownTargetActivityStamp(left);
+      const b = knownTargetActivityStamp(right);
       return b.localeCompare(a);
     });
+}
+
+function knownTargetActivityStamp(target: KnownTarget): string {
+  return target.updatedAt ?? target.lastTunneledAt ?? target.lastSyncedAt ?? "";
+}
+
+function collapseKnownTargetsByRemote(targets: KnownTarget[]): KnownTarget[] {
+  const seen = new Set<string>();
+  const collapsed: KnownTarget[] = [];
+  for (const target of targets) {
+    if (seen.has(target.remote)) continue;
+    seen.add(target.remote);
+    collapsed.push(target);
+  }
+  return collapsed;
+}
+
+function formatKnownTargetChoice(target: KnownTarget): string {
+  const vmName = target.remoteHost ?? target.remote;
+  const parts = [
+    `vm=${vmName}`,
+    `remote=${target.remote}`,
+    `repo=${target.repo}`,
+    `base=${target.base}`,
+  ];
+  const lastUsed = knownTargetActivityStamp(target);
+  if (lastUsed) {
+    parts.push(`last_used=${lastUsed}`);
+  }
+  return parts.join(" ");
+}
+
+async function promptLine(prompt: string): Promise<string> {
+  process.stderr.write(prompt);
+  process.stdin.setEncoding("utf8");
+  return await new Promise<string>((resolve) => {
+    process.stdin.once("data", (data) => resolve(String(data)));
+  });
+}
+
+async function chooseKnownTarget(
+  promptMessage: string,
+  targets: KnownTarget[],
+): Promise<KnownTarget | undefined> {
+  if (targets.length === 0) return undefined;
+  if (targets.length === 1 || !process.stdin.isTTY) {
+    return targets[0];
+  }
+
+  process.stderr.write(`${promptMessage}\n`);
+  targets.forEach((target, index) => {
+    process.stderr.write(`  ${index + 1}. ${formatKnownTargetChoice(target)}\n`);
+  });
+
+  while (true) {
+    const input = (await promptLine(`Select target [1-${targets.length}] (default 1): `)).trim();
+    if (input === "") return targets[0];
+    if (/^\d+$/.test(input)) {
+      const selected = Number.parseInt(input, 10);
+      if (selected >= 1 && selected <= targets.length) {
+        return targets[selected - 1];
+      }
+    }
+    process.stderr.write(`Invalid selection: ${input || "(empty)"}\n`);
+  }
+}
+
+async function resolveRememberedTarget(params: {
+  config: CodeboxConfig;
+  repo: string;
+  remote?: string;
+  base?: string;
+  requireRepoMatch?: boolean;
+}): Promise<KnownTarget | undefined> {
+  const repoTargets = selectKnownTargets(params.config, {
+    repo: params.repo,
+    remote: params.remote,
+    base: params.base,
+  });
+
+  if (params.requireRepoMatch) {
+    return await chooseKnownTarget(
+      `Select remembered target for repo "${params.repo}":`,
+      repoTargets,
+    );
+  }
+
+  if (params.remote) {
+    return repoTargets[0];
+  }
+
+  const repoMatch = await chooseKnownTarget(
+    `Select recent target for repo "${params.repo}":`,
+    repoTargets,
+  );
+  if (repoMatch) return repoMatch;
+
+  const recentRemoteTargets = collapseKnownTargetsByRemote(
+    selectKnownTargets(params.config, { base: params.base }),
+  );
+  return await chooseKnownTarget("Select recent remote target:", recentRemoteTargets);
 }
 
 function canShareTunnel(a: KnownTarget, b: Pick<KnownTarget, "remote" | "opencodeRemotePort">): boolean {
@@ -444,8 +548,11 @@ function parsePort(raw: string | undefined, name: string, fallback: number): num
 }
 
 function parseOpencodeSupervisor(raw: string | undefined): OpencodeSupervisor {
-  const text = (raw ?? "auto").trim().toLowerCase();
-  if (text === "" || text === "auto") return "auto";
+  const text = (raw ?? DEFAULT_OPENCODE_SUPERVISOR).trim().toLowerCase();
+  if (text === "" || text === DEFAULT_OPENCODE_SUPERVISOR) {
+    return DEFAULT_OPENCODE_SUPERVISOR;
+  }
+  if (text === "auto") return "auto";
   if (text === "nohup") return "nohup";
   if (text === "systemd") return "systemd";
   throw new Error(
@@ -642,11 +749,7 @@ async function promptYes(message: string, assumeYes: boolean): Promise<void> {
   if (!process.stdin.isTTY) {
     throw new Error(`${message} Use --yes to proceed or disable the option.`);
   }
-  process.stderr.write(`${message} Type 'yes' to continue: `);
-  process.stdin.setEncoding("utf8");
-  const input = await new Promise<string>((resolve) => {
-    process.stdin.once("data", (data) => resolve(String(data)));
-  });
+  const input = await promptLine(`${message} Type 'yes' to continue: `);
   if (input.trim().toLowerCase() !== "yes") {
     throw new Error("Aborted.");
   }
@@ -938,8 +1041,8 @@ async function listKnownTargets(config: CodeboxConfig): Promise<string[]> {
   const targets = getKnownTargetEntries(config)
     .map(([, target]) => target)
     .sort((left, right) => {
-      const a = left.updatedAt ?? left.lastTunneledAt ?? left.lastSyncedAt ?? "";
-      const b = right.updatedAt ?? right.lastTunneledAt ?? right.lastSyncedAt ?? "";
+      const a = knownTargetActivityStamp(left);
+      const b = knownTargetActivityStamp(right);
       return b.localeCompare(a);
     });
   const lines: string[] = [];
@@ -1025,28 +1128,24 @@ async function main() {
     throw new Error("Cannot combine --list and --all in tunnel mode.");
   }
 
+  const repoRoot = resolve(process.cwd());
+  const repoName = requestedRepo ?? basename(repoRoot);
   const requestedBase = argValue(args, "--base") ?? process.env.BASE;
   const requestedRemoteHint =
     argValue(args, "--remote") ?? positionalRemote ?? process.env.REMOTE;
   const rememberedTarget =
-    requestedRepo && !tunnelListMode && !tunnelAllMode
-      ? (() => {
-          const matches = selectKnownTargets(existingConfig, {
-            repo: requestedRepo,
-            remote: requestedRemoteHint,
-            base: requestedBase,
-          });
-          if (matches.length === 0) {
-            throw new Error(`No remembered target found for repo "${requestedRepo}".`);
-          }
-          if (matches.length > 1) {
-            throw new Error(
-              `Multiple remembered targets found for repo "${requestedRepo}". Pass --remote to disambiguate.`,
-            );
-          }
-          return matches[0];
-        })()
+    !tunnelListMode && !tunnelAllMode
+      ? await resolveRememberedTarget({
+          config: existingConfig,
+          repo: repoName,
+          remote: requestedRemoteHint,
+          base: requestedBase,
+          requireRepoMatch: Boolean(requestedRepo),
+        })
       : undefined;
+  if (requestedRepo && !tunnelListMode && !tunnelAllMode && !rememberedTarget) {
+    throw new Error(`No remembered target found for repo "${requestedRepo}".`);
+  }
 
   const sshOpts =
     argValue(args, "--ssh-opts") ??
@@ -1060,11 +1159,7 @@ async function main() {
   const base =
     requestedBase ??
     rememberedTarget?.base ??
-    process.env.BASE ??
-    (typeof existingConfig.last_base === "string" ? existingConfig.last_base : undefined) ??
-    "$HOME/workspace";
-  const repoRoot = resolve(process.cwd());
-  const repoName = rememberedTarget?.repo ?? basename(repoRoot);
+    DEFAULT_BASE;
   const remoteRepo = rememberedTarget?.remoteRepo ?? `${base}/${repoName}`;
 
   if (mode === "sync") {
@@ -1166,9 +1261,7 @@ async function main() {
   }
 
   const remote =
-    argValue(args, "--remote") ??
-    positionalRemote ??
-    process.env.REMOTE ??
+    requestedRemoteHint ??
     rememberedTarget?.remote ??
     (typeof existingConfig.last_remote === "string" ? existingConfig.last_remote : undefined);
   if (!remote) {

--- a/codebox.ts
+++ b/codebox.ts
@@ -140,9 +140,16 @@ function collectEnvVars(args: string[]): Record<string, string> {
   const allow = new Set<string>([...defaults, ...extraNames]);
   const allPrefixes = [...prefixes, ...extraPrefixes];
 
+  const skip = new Set<string>([
+    "OPENCODE_PID",
+    "OPENCODE_SESSION",
+    "CODEX_PID",
+  ]);
+
   const out: Record<string, string> = {};
   for (const [key, val] of Object.entries(process.env)) {
     if (val == null || val === "") continue;
+    if (skip.has(key)) continue;
     if (allow.has(key)) {
       out[key] = val;
       continue;
@@ -561,7 +568,7 @@ function rsyncCmd(
     "--stats",
   ];
   if (verbose) {
-    cmd.push("-v", "--info=progress2");
+    cmd.push("-v", "--progress");
   }
   cmd.push("-e", `ssh ${sshOpts}`);
   for (const ex of excludes) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bun": ">=1.0.0"
   },
   "scripts": {
-    "test": "node tests/integration/install.test.mjs && node tests/integration/ssh.test.mjs",
+    "test": "node tests/integration/install.test.mjs && node tests/integration/ssh.test.mjs && node tests/integration/sync.test.mjs && node tests/integration/tunnel-registry.test.mjs",
     "install:devbox": "bun run scripts/install-devbox.ts"
   },
   "keywords": [

--- a/tests/integration/install.test.mjs
+++ b/tests/integration/install.test.mjs
@@ -82,6 +82,8 @@ try {
       `codebox --help failed: ${helpResult.stderr || helpResult.stdout}`,
     );
     assert.match(helpResult.stdout + helpResult.stderr, /Usage:/);
+    assert.match(helpResult.stdout + helpResult.stderr, /--opencode-ref <branch\|sha>/);
+    assert.match(helpResult.stdout + helpResult.stderr, /default: "dev"/);
   } else if (process.platform !== "win32") {
     const contents = readFileSync(codeboxBin, "utf8");
     const firstLine = contents.split("\n")[0] ?? "";

--- a/tests/integration/install.test.mjs
+++ b/tests/integration/install.test.mjs
@@ -82,8 +82,16 @@ try {
       `codebox --help failed: ${helpResult.stderr || helpResult.stdout}`,
     );
     assert.match(helpResult.stdout + helpResult.stderr, /Usage:/);
+    assert.match(
+      helpResult.stdout + helpResult.stderr,
+      /--base <path>\s+Remote base dir \(default: "\$HOME\/workspace"\)/,
+    );
     assert.match(helpResult.stdout + helpResult.stderr, /--opencode-ref <branch\|sha>/);
     assert.match(helpResult.stdout + helpResult.stderr, /default: "dev"/);
+    assert.match(
+      helpResult.stdout + helpResult.stderr,
+      /--opencode-supervisor <m>\s+Remote OpenCode supervisor: auto\|nohup\|systemd \(default: systemd\)/,
+    );
   } else if (process.platform !== "win32") {
     const contents = readFileSync(codeboxBin, "utf8");
     const firstLine = contents.split("\n")[0] ?? "";

--- a/tests/integration/ssh.test.mjs
+++ b/tests/integration/ssh.test.mjs
@@ -14,7 +14,7 @@ writeFileSync(
   configPath,
   JSON.stringify({
     last_remote: "cached-user@cached-host",
-    last_base: "$HOME/workspace",
+    last_base: "/srv/legacy-workspace",
   }) + "\n",
 );
 
@@ -67,6 +67,8 @@ try {
   const remoteOut = `${remoteCommand.stdout}\n${remoteCommand.stderr}`;
   assert.match(remoteOut, /\[dry-run\] ssh /);
   assert.match(remoteOut, /cached-user@cached-host bash -lc/);
+  assert.match(remoteOut, /\$HOME\/workspace\/codebox/);
+  assert.doesNotMatch(remoteOut, /\/srv\/legacy-workspace\/codebox/);
   assert.match(remoteOut, /exec .*pwd/);
 
   const tunnelCommand = runTunnel([
@@ -88,6 +90,59 @@ try {
   assert.match(tunnelModeOut, /-f -N/);
   assert.match(tunnelModeOut, /-L 4901:127\.0\.0\.1:4902/);
   assert.match(tunnelModeOut, /cached-user@cached-host/);
+
+  const rememberedTargetsConfigPath = path.join(tempRoot, "remembered-targets.json");
+  writeFileSync(
+    rememberedTargetsConfigPath,
+    JSON.stringify(
+      {
+        known_targets: {
+          "recent-user@vm-2::$HOME/workspace::codebox": {
+            remote: "recent-user@vm-2",
+            remoteHost: "vm-2",
+            sshOpts: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes",
+            base: "$HOME/workspace",
+            repo: "codebox",
+            remoteRepo: "$HOME/workspace/codebox",
+            opencodeLocalPort: 5551,
+            opencodeRemotePort: 5551,
+            lastSyncedAt: "2026-03-29T02:00:00.000Z",
+            updatedAt: "2026-03-29T02:00:00.000Z",
+          },
+          "older-user@vm-1::$HOME/workspace::codebox": {
+            remote: "older-user@vm-1",
+            remoteHost: "vm-1",
+            sshOpts: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes",
+            base: "$HOME/workspace",
+            repo: "codebox",
+            remoteRepo: "$HOME/workspace/codebox",
+            opencodeLocalPort: 5551,
+            opencodeRemotePort: 5551,
+            lastSyncedAt: "2026-03-29T01:00:00.000Z",
+            updatedAt: "2026-03-29T01:00:00.000Z",
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  const recentRemoteFallback = runSsh([
+    "--config",
+    rememberedTargetsConfigPath,
+    "--dry-run",
+    "--",
+    "pwd",
+  ]);
+  assert.equal(
+    recentRemoteFallback.status,
+    0,
+    `Recent-remote ssh dry-run failed: ${recentRemoteFallback.stderr || recentRemoteFallback.stdout}`,
+  );
+  const recentRemoteOut = `${recentRemoteFallback.stdout}\n${recentRemoteFallback.stderr}`;
+  assert.match(recentRemoteOut, /recent-user@vm-2 bash -lc/);
+  assert.doesNotMatch(recentRemoteOut, /older-user@vm-1 bash -lc/);
 } finally {
   rmSync(tempRoot, { recursive: true, force: true });
 }

--- a/tests/integration/sync.test.mjs
+++ b/tests/integration/sync.test.mjs
@@ -85,11 +85,13 @@ try {
   assert.match(defaultOut, /OPENCODE_REPO_URL=\$'https:\/\/github\.com\/dzianisv\/opencode\.git'/);
   assert.match(defaultOut, /OPENCODE_REF=\$'dev'/);
   assert.match(defaultOut, /OPENCODE_SYNC_LOCAL_SOURCE=\$'0'/);
+  assert.match(defaultOut, /OPENCODE_SUPERVISOR=\$'systemd'/);
   assert.match(defaultOut, /git -C "\$OPENCODE_DIR" fetch --force --tags --prune origin/);
   assert.match(
     defaultOut,
     /git -C "\$OPENCODE_DIR" checkout -B "\$OPENCODE_REF" "refs\/remotes\/origin\/\$OPENCODE_REF"/,
   );
+  assert.match(defaultOut, /systemd_user_cmd stop opencode-serve\.service/);
   assert.doesNotMatch(defaultOut, /sync opencode repo/);
 
   const withSystemd = runSync([

--- a/tests/integration/sync.test.mjs
+++ b/tests/integration/sync.test.mjs
@@ -99,13 +99,30 @@ try {
   );
   assert.match(systemdOut, /bun run install:local/);
   assert.match(systemdOut, /bun run --cwd packages\/opencode install:local/);
-  assert.match(systemdOut, /WorkingDirectory=\$REMOTE_BASE/);
+  assert.match(systemdOut, /WorkingDirectory=\$OPENCODE_DIR/);
   assert.match(
     systemdOut,
-    /ExecStart=.*\$HOME\/\.local\/bin\/opencode.*\$HOME\/\.opencode\/bin\/opencode.*exec "\\\$OPENCODE_BIN" serve --hostname 127\.0\.0\.1 --port 5551/,
+    /ExecStart=.*\$HOME\/\.local\/bin\/opencode.*\$HOME\/\.opencode\/bin\/opencode.*export OPENCODE_DISABLE_CHANNEL_DB="\$\{OPENCODE_DISABLE_CHANNEL_DB:-1\}".*exec "\\\$OPENCODE_BIN" serve --hostname 127\.0\.0\.1 --port 5551/,
   );
   assert.match(systemdOut, /opencode-serve\.service/);
   assert.match(systemdOut, /systemctl --user/);
+
+  const withNohup = runSync([
+    "--opencode-supervisor",
+    "nohup",
+    "--opencode-src",
+    goodOpencodeRepo,
+  ]);
+  assert.equal(
+    withNohup.status,
+    0,
+    `Sync dry-run with nohup failed: ${withNohup.stderr || withNohup.stdout}`,
+  );
+  const nohupOut = `${withNohup.stdout}\n${withNohup.stderr}`;
+  assert.match(
+    nohupOut,
+    /cd "\$OPENCODE_DIR" &&[\s\S]*OPENCODE_DISABLE_CHANNEL_DB="\$\{OPENCODE_DISABLE_CHANNEL_DB:-1\}"[\s\S]*nohup "\$OPENCODE_BIN" serve --hostname 127\.0\.0\.1 --port "\$OPENCODE_PORT"/,
+  );
 
   const withoutAuth = runSync(["--no-opencode-auth", "--opencode-src", goodOpencodeRepo]);
   assert.equal(

--- a/tests/integration/sync.test.mjs
+++ b/tests/integration/sync.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+const tempHome = mkdtempSync(path.join(os.tmpdir(), "codebox-sync-home-"));
+const tempRepos = mkdtempSync(path.join(os.tmpdir(), "codebox-sync-repos-"));
+const goodOpencodeRepo = path.join(tempRepos, "opencode-good");
+const badOpencodeRepo = path.join(tempRepos, "opencode-bad");
+
+mkdirSync(path.join(tempHome, ".config", "opencode"), { recursive: true });
+mkdirSync(path.join(tempHome, ".local", "share", "opencode"), { recursive: true });
+
+writeFileSync(
+  path.join(tempHome, ".config", "opencode", "opencode.json"),
+  JSON.stringify({ provider: { "github-copilot": {} } }) + "\n",
+);
+writeFileSync(
+  path.join(tempHome, ".local", "share", "opencode", "auth.json"),
+  JSON.stringify({
+    "github-copilot": {
+      type: "oauth",
+      refresh: "gho_test_refresh",
+      access: "gho_test_access",
+      expires: 0,
+    },
+  }) + "\n",
+);
+
+function initGitRepo(dir, originUrl) {
+  mkdirSync(dir, { recursive: true });
+  const initResult = spawnSync("git", ["init", "-q"], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  assert.equal(initResult.status, 0, initResult.stderr || initResult.stdout);
+
+  const addRemoteResult = spawnSync("git", ["remote", "add", "origin", originUrl], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  assert.equal(addRemoteResult.status, 0, addRemoteResult.stderr || addRemoteResult.stdout);
+}
+
+initGitRepo(goodOpencodeRepo, "git@github.com:dzianisv/opencode.git");
+initGitRepo(badOpencodeRepo, "https://github.com/example/not-opencode.git");
+
+function runSync(args) {
+  return spawnSync(
+    "bun",
+    [
+      "codebox.ts",
+      "--remote",
+      "dev@host",
+      "--dry-run",
+      "--no-env",
+      "--no-codex-config",
+      "--no-gh-config",
+      "--no-opencode-tunnel",
+      ...args,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: tempHome,
+      },
+    },
+  );
+}
+
+try {
+  const withSystemd = runSync([
+    "--opencode-supervisor",
+    "systemd",
+    "--opencode-src",
+    goodOpencodeRepo,
+  ]);
+  assert.equal(
+    withSystemd.status,
+    0,
+    `Sync dry-run with systemd failed: ${withSystemd.stderr || withSystemd.stdout}`,
+  );
+  const systemdOut = `${withSystemd.stdout}\n${withSystemd.stderr}`;
+  assert.match(systemdOut, /sync ~\/\.config\/opencode/);
+  assert.match(systemdOut, /sync ~\/\.local\/share\/opencode\/auth\.json/);
+  assert.match(systemdOut, /OPENCODE_REPO_URL=\$'https:\/\/github\.com\/dzianisv\/opencode\.git'/);
+  assert.match(systemdOut, /OPENCODE_SUPERVISOR=\$'systemd'/);
+  assert.match(systemdOut, /git clone "\$OPENCODE_REPO_URL" "\$scratch_dir\/repo"/);
+  assert.match(systemdOut, /systemd_user_cmd stop opencode-serve\.service/);
+  assert.match(
+    systemdOut,
+    /resolve_opencode_bin\(\) \{[\s\S]*\$HOME\/\.local\/bin\/opencode[\s\S]*\$HOME\/\.opencode\/bin\/opencode/,
+  );
+  assert.match(systemdOut, /bun run install:local/);
+  assert.match(systemdOut, /bun run --cwd packages\/opencode install:local/);
+  assert.match(systemdOut, /WorkingDirectory=\$REMOTE_BASE/);
+  assert.match(
+    systemdOut,
+    /ExecStart=.*\$HOME\/\.local\/bin\/opencode.*\$HOME\/\.opencode\/bin\/opencode.*exec "\\\$OPENCODE_BIN" serve --hostname 127\.0\.0\.1 --port 5551/,
+  );
+  assert.match(systemdOut, /opencode-serve\.service/);
+  assert.match(systemdOut, /systemctl --user/);
+
+  const withoutAuth = runSync(["--no-opencode-auth", "--opencode-src", goodOpencodeRepo]);
+  assert.equal(
+    withoutAuth.status,
+    0,
+    `Sync dry-run without auth sync failed: ${withoutAuth.stderr || withoutAuth.stdout}`,
+  );
+  const withoutAuthOut = `${withoutAuth.stdout}\n${withoutAuth.stderr}`;
+  assert.doesNotMatch(withoutAuthOut, /sync ~\/\.local\/share\/opencode\/auth\.json/);
+
+  const badFork = runSync(["--opencode-src", badOpencodeRepo]);
+  assert.notEqual(badFork.status, 0, "Expected sync to reject non-fork OpenCode source");
+  assert.match(
+    `${badFork.stdout}\n${badFork.stderr}`,
+    /does not match required fork/,
+  );
+} finally {
+  rmSync(tempHome, { recursive: true, force: true });
+  rmSync(tempRepos, { recursive: true, force: true });
+}

--- a/tests/integration/sync.test.mjs
+++ b/tests/integration/sync.test.mjs
@@ -75,6 +75,23 @@ function runSync(args) {
 }
 
 try {
+  const defaultManagedOpencode = runSync([]);
+  assert.equal(
+    defaultManagedOpencode.status,
+    0,
+    `Default sync dry-run failed: ${defaultManagedOpencode.stderr || defaultManagedOpencode.stdout}`,
+  );
+  const defaultOut = `${defaultManagedOpencode.stdout}\n${defaultManagedOpencode.stderr}`;
+  assert.match(defaultOut, /OPENCODE_REPO_URL=\$'https:\/\/github\.com\/dzianisv\/opencode\.git'/);
+  assert.match(defaultOut, /OPENCODE_REF=\$'dev'/);
+  assert.match(defaultOut, /OPENCODE_SYNC_LOCAL_SOURCE=\$'0'/);
+  assert.match(defaultOut, /git -C "\$OPENCODE_DIR" fetch --force --tags --prune origin/);
+  assert.match(
+    defaultOut,
+    /git -C "\$OPENCODE_DIR" checkout -B "\$OPENCODE_REF" "refs\/remotes\/origin\/\$OPENCODE_REF"/,
+  );
+  assert.doesNotMatch(defaultOut, /sync opencode repo/);
+
   const withSystemd = runSync([
     "--opencode-supervisor",
     "systemd",
@@ -90,8 +107,11 @@ try {
   assert.match(systemdOut, /sync ~\/\.config\/opencode/);
   assert.match(systemdOut, /sync ~\/\.local\/share\/opencode\/auth\.json/);
   assert.match(systemdOut, /OPENCODE_REPO_URL=\$'https:\/\/github\.com\/dzianisv\/opencode\.git'/);
+  assert.match(systemdOut, /OPENCODE_REF=\$'dev'/);
+  assert.match(systemdOut, /OPENCODE_SYNC_LOCAL_SOURCE=\$'1'/);
   assert.match(systemdOut, /OPENCODE_SUPERVISOR=\$'systemd'/);
   assert.match(systemdOut, /git clone "\$OPENCODE_REPO_URL" "\$scratch_dir\/repo"/);
+  assert.match(systemdOut, /preserving synced local OpenCode source/);
   assert.match(systemdOut, /systemd_user_cmd stop opencode-serve\.service/);
   assert.match(
     systemdOut,

--- a/tests/integration/tunnel-registry.test.mjs
+++ b/tests/integration/tunnel-registry.test.mjs
@@ -57,6 +57,7 @@ async function occupyPort() {
 try {
   const rememberedPort = await getFreePort();
   const secondRememberedPort = await getFreePort();
+  const thirdRememberedPort = await getFreePort();
   const configPath = path.join(tempRoot, "codebox.json");
   writeFileSync(
     configPath,
@@ -90,6 +91,18 @@ try {
             lastSyncedAt: "2026-03-28T23:00:00.000Z",
             updatedAt: "2026-03-28T23:00:00.000Z",
           },
+          "older-user@older-host::$HOME/workspace::demo-repo": {
+            remote: "older-user@older-host",
+            remoteHost: "vm-gamma",
+            sshOpts: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes",
+            base: "$HOME/workspace",
+            repo: "demo-repo",
+            remoteRepo: "$HOME/workspace/demo-repo",
+            opencodeLocalPort: thirdRememberedPort,
+            opencodeRemotePort: 5551,
+            lastSyncedAt: "2026-03-28T22:00:00.000Z",
+            updatedAt: "2026-03-28T22:00:00.000Z",
+          },
         },
       },
       null,
@@ -109,6 +122,7 @@ try {
   assert.match(listedOut, new RegExp(`local=http://127\\.0\\.0\\.1:${rememberedPort}`));
   assert.match(listedOut, /vm=vm-beta/);
   assert.match(listedOut, /repo=demo-repo/);
+  assert.match(listedOut, /vm=vm-gamma/);
 
   const allDryRun = runCodebox(["tunnel", "--all", "--config", configPath, "--dry-run"]);
   assert.equal(
@@ -155,6 +169,10 @@ try {
   assert.match(
     selectedRepoOut,
     new RegExp(`-L ${secondRememberedPort}:127\\.0\\.0\\.1:5551 other-user@other-host`),
+  );
+  assert.doesNotMatch(
+    selectedRepoOut,
+    new RegExp(`-L ${thirdRememberedPort}:127\\.0\\.0\\.1:5551 older-user@older-host`),
   );
 
   const occupied = await occupyPort();

--- a/tests/integration/tunnel-registry.test.mjs
+++ b/tests/integration/tunnel-registry.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+const tempRoot = mkdtempSync(path.join(os.tmpdir(), "codebox-tunnel-registry-"));
+
+function runCodebox(args) {
+  return spawnSync("bun", ["codebox.ts", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Unable to determine free port"));
+        return;
+      }
+      const { port } = address;
+      server.close((closeError) => {
+        if (closeError) {
+          reject(closeError);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function occupyPort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Unable to determine occupied port"));
+        return;
+      }
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+try {
+  const rememberedPort = await getFreePort();
+  const secondRememberedPort = await getFreePort();
+  const configPath = path.join(tempRoot, "codebox.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        last_remote: "cached-user@cached-host",
+        last_base: "$HOME/workspace",
+        last_repo: "codebox",
+        known_targets: {
+          "cached-user@cached-host::$HOME/workspace::codebox": {
+            remote: "cached-user@cached-host",
+            remoteHost: "vm-alpha",
+            sshOpts: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes",
+            base: "$HOME/workspace",
+            repo: "codebox",
+            remoteRepo: "$HOME/workspace/codebox",
+            opencodeLocalPort: rememberedPort,
+            opencodeRemotePort: 5551,
+            lastSyncedAt: "2026-03-29T00:00:00.000Z",
+            updatedAt: "2026-03-29T00:00:00.000Z",
+          },
+          "other-user@other-host::$HOME/workspace::demo-repo": {
+            remote: "other-user@other-host",
+            remoteHost: "vm-beta",
+            sshOpts: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes",
+            base: "$HOME/workspace",
+            repo: "demo-repo",
+            remoteRepo: "$HOME/workspace/demo-repo",
+            opencodeLocalPort: secondRememberedPort,
+            opencodeRemotePort: 5551,
+            lastSyncedAt: "2026-03-28T23:00:00.000Z",
+            updatedAt: "2026-03-28T23:00:00.000Z",
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  const listed = runCodebox(["tunnel", "--list", "--config", configPath]);
+  assert.equal(
+    listed.status,
+    0,
+    `Tunnel list failed: ${listed.stderr || listed.stdout}`,
+  );
+  const listedOut = `${listed.stdout}\n${listed.stderr}`;
+  assert.match(listedOut, /vm=vm-alpha/);
+  assert.match(listedOut, /repo=codebox/);
+  assert.match(listedOut, new RegExp(`local=http://127\\.0\\.0\\.1:${rememberedPort}`));
+  assert.match(listedOut, /vm=vm-beta/);
+  assert.match(listedOut, /repo=demo-repo/);
+
+  const allDryRun = runCodebox(["tunnel", "--all", "--config", configPath, "--dry-run"]);
+  assert.equal(
+    allDryRun.status,
+    0,
+    `Tunnel --all dry-run failed: ${allDryRun.stderr || allDryRun.stdout}`,
+  );
+  const allDryRunOut = `${allDryRun.stdout}\n${allDryRun.stderr}`;
+  assert.match(
+    allDryRunOut,
+    new RegExp(`-L ${rememberedPort}:127\\.0\\.0\\.1:5551 cached-user@cached-host`),
+  );
+  assert.match(
+    allDryRunOut,
+    new RegExp(`-L ${secondRememberedPort}:127\\.0\\.0\\.1:5551 other-user@other-host`),
+  );
+
+  const singleDryRun = runCodebox(["tunnel", "--config", configPath, "--dry-run"]);
+  assert.equal(
+    singleDryRun.status,
+    0,
+    `Single tunnel dry-run failed: ${singleDryRun.stderr || singleDryRun.stdout}`,
+  );
+  const singleDryRunOut = `${singleDryRun.stdout}\n${singleDryRun.stderr}`;
+  assert.match(
+    singleDryRunOut,
+    new RegExp(`-L ${rememberedPort}:127\\.0\\.0\\.1:5551 cached-user@cached-host`),
+  );
+
+  const selectedRepoDryRun = runCodebox([
+    "tunnel",
+    "--repo",
+    "demo-repo",
+    "--config",
+    configPath,
+    "--dry-run",
+  ]);
+  assert.equal(
+    selectedRepoDryRun.status,
+    0,
+    `Repo-selected tunnel dry-run failed: ${selectedRepoDryRun.stderr || selectedRepoDryRun.stdout}`,
+  );
+  const selectedRepoOut = `${selectedRepoDryRun.stdout}\n${selectedRepoDryRun.stderr}`;
+  assert.match(
+    selectedRepoOut,
+    new RegExp(`-L ${secondRememberedPort}:127\\.0\\.0\\.1:5551 other-user@other-host`),
+  );
+
+  const occupied = await occupyPort();
+  try {
+    const occupiedConfigPath = path.join(tempRoot, "occupied-codebox.json");
+    writeFileSync(
+      occupiedConfigPath,
+      JSON.stringify(
+        {
+          last_remote: "cached-user@cached-host",
+          last_base: "$HOME/workspace",
+          last_repo: "codebox",
+          known_targets: {
+            "cached-user@cached-host::$HOME/workspace::codebox": {
+              remote: "cached-user@cached-host",
+              remoteHost: "vm-alpha",
+              sshOpts: "-i ~/.ssh/id_rsa -o IdentitiesOnly=yes",
+              base: "$HOME/workspace",
+              repo: "codebox",
+              remoteRepo: "$HOME/workspace/codebox",
+              opencodeLocalPort: occupied.port,
+              opencodeRemotePort: 5551,
+              lastSyncedAt: "2026-03-29T00:00:00.000Z",
+              updatedAt: "2026-03-29T00:00:00.000Z",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const reassigned = runCodebox(["tunnel", "--config", occupiedConfigPath, "--dry-run"]);
+    assert.equal(
+      reassigned.status,
+      0,
+      `Occupied-port tunnel dry-run failed: ${reassigned.stderr || reassigned.stdout}`,
+    );
+    const reassignedOut = `${reassigned.stdout}\n${reassigned.stderr}`;
+    const match = reassignedOut.match(/-L (\d+):127\.0\.0\.1:5551 cached-user@cached-host/);
+    assert.ok(match, `Did not find reassigned tunnel command in output: ${reassignedOut}`);
+    const assignedPort = Number.parseInt(match[1], 10);
+    assert.notEqual(assignedPort, occupied.port, "Expected occupied remembered port to be reassigned");
+  } finally {
+    await new Promise((resolve, reject) => {
+      occupied.server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- remember synced/tunneled OpenCode targets and add `codebox tunnel --list`, `--all`, and `--repo`
- support sync-side OpenCode auth/env improvements and repo-specific excludes for VM handoff flows
- fix remote OpenCode bootstrap/runtime selection so repo-local installs are used, the managed runtime serves from the remote OpenCode checkout, and it preserves the shared OpenCode DB when switching from channel binaries to repo-local builds
- default the managed remote OpenCode checkout to `https://github.com/dzianisv/opencode.git` at ref `dev`, with `--opencode-ref` available for explicit branch or commit overrides
- prompt from remembered recent VM targets when `--remote` is omitted, default the remote base back to `$HOME/workspace`, and make `systemd` the default OpenCode supervisor
- add sync/tunnel integration coverage for the remembered-target registry and OpenCode install/runtime precedence

## Testing
- `npm test`
- verified the live Azure VM now serves the `dzianisv/opencode` `dev` frontend asset hashes through `http://127.0.0.1:5551`
- verified `session?directory=/home/azureuser/workspace/termux-app` returns the expected sessions through the localhost tunnel
- verified the browser UI shows the restored recent sessions and opens them successfully
- verified a real `codebox` sync without `--opencode-src` now fetches `origin/dev`, rebuilds OpenCode, and leaves the VM serving the expected `dev` build and sessions
- verified the new TTY chooser lists remembered VM targets and applies the selected remote in `codebox ssh --dry-run`

## Issues
Closes #2
Closes #3
Closes #5
Closes #6
Closes #7
