### PR TITLE
feat: build and start paperclip from source fork with github-copilot models

### DIFF
--- a/codebox.ts
+++ b/codebox.ts
@@ -2233,6 +2233,15 @@ start_paperclip() {
     echo "Warning: paperclip CLI dist not found at $paperclip_cli; skipping start"
     return 0
   fi
+  local paperclip_bind
+  local paperclip_health_host
+  if [ "$DISABLE_TAILSCALE" = "1" ]; then
+    paperclip_bind="localhost"
+    paperclip_health_host="127.0.0.1"
+  else
+    paperclip_bind="tailnet"
+    paperclip_health_host="\${TAILSCALE_IP:-127.0.0.1}"
+  fi
   local pids
   pids="$(pgrep -f paperclipai 2>/dev/null || true)"
   if [ -n "$pids" ]; then
@@ -2241,12 +2250,12 @@ start_paperclip() {
     sleep 2
   fi
   mkdir -p "$HOME/.paperclip"
-  echo "Info: Starting paperclip from source build..."
-  nohup node "$paperclip_cli" onboard --yes --bind tailnet >> "$HOME/.paperclip/server.log" 2>&1 &
+  echo "Info: Starting paperclip from source build (bind: $paperclip_bind)..."
+  nohup node "$paperclip_cli" onboard --yes --bind "$paperclip_bind" >> "$HOME/.paperclip/server.log" 2>&1 &
   echo "Info: paperclip started (PID $!)"
   for _ in $(seq 1 30); do
     sleep 1
-    if curl -sf "http://$(tailscale ip -4 2>/dev/null || echo 127.0.0.1):3100/api/health" >/dev/null 2>&1; then
+    if curl -sf "http://$paperclip_health_host:3100/api/health" >/dev/null 2>&1; then
       echo "Info: paperclip is ready"
       return 0
     fi
@@ -2520,8 +2529,6 @@ if [ -d "$OPENCODE_DIR" ]; then
 fi
 
 install_paperclip
-start_paperclip
-install_copilot_cli
 
 # Symlink tools into /usr/local/bin so nohup/systemd processes (e.g. paperclip) can find them
 # Must run after opencode and codex are installed into ~/.local/bin
@@ -2535,6 +2542,9 @@ if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
 else
   echo "Warning: sudo not available; skipping /usr/local/bin symlinks for codex/opencode"
 fi
+
+start_paperclip
+install_copilot_cli
 
 start_chrome_cdp_systemd
 

--- a/codebox.ts
+++ b/codebox.ts
@@ -2223,6 +2223,35 @@ install_paperclip() {
   fi
   echo "Info: Running pnpm install in $PAPERCLIP_DIR"
   (cd "$PAPERCLIP_DIR" && pnpm install) || echo "Warning: pnpm install failed in $PAPERCLIP_DIR"
+  echo "Info: Building paperclip from source in $PAPERCLIP_DIR"
+  (cd "$PAPERCLIP_DIR" && pnpm -r build) || echo "Warning: pnpm build failed in $PAPERCLIP_DIR"
+}
+
+start_paperclip() {
+  local paperclip_cli="$PAPERCLIP_DIR/cli/dist/index.js"
+  if [ ! -f "$paperclip_cli" ]; then
+    echo "Warning: paperclip CLI dist not found at $paperclip_cli; skipping start"
+    return 0
+  fi
+  local pids
+  pids="$(pgrep -f paperclipai 2>/dev/null || true)"
+  if [ -n "$pids" ]; then
+    echo "Info: Killing existing paperclip processes: $pids"
+    for pid in $pids; do kill "$pid" 2>/dev/null || true; done
+    sleep 2
+  fi
+  mkdir -p "$HOME/.paperclip"
+  echo "Info: Starting paperclip from source build..."
+  nohup node "$paperclip_cli" onboard --yes --bind tailnet >> "$HOME/.paperclip/server.log" 2>&1 &
+  echo "Info: paperclip started (PID $!)"
+  for _ in $(seq 1 30); do
+    sleep 1
+    if curl -sf "http://$(tailscale ip -4 2>/dev/null || echo 127.0.0.1):3100/api/health" >/dev/null 2>&1; then
+      echo "Info: paperclip is ready"
+      return 0
+    fi
+  done
+  echo "Warning: paperclip did not become ready after 30s"
 }
 
 install_copilot_cli() {
@@ -2491,6 +2520,7 @@ if [ -d "$OPENCODE_DIR" ]; then
 fi
 
 install_paperclip
+start_paperclip
 install_copilot_cli
 
 start_chrome_cdp_systemd

--- a/codebox.ts
+++ b/codebox.ts
@@ -2523,6 +2523,19 @@ install_paperclip
 start_paperclip
 install_copilot_cli
 
+# Symlink tools into /usr/local/bin so nohup/systemd processes (e.g. paperclip) can find them
+# Must run after opencode and codex are installed into ~/.local/bin
+if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  for tool_bin in codex opencode; do
+    if [ -x "$HOME/.local/bin/$tool_bin" ]; then
+      sudo ln -sf "$HOME/.local/bin/$tool_bin" "/usr/local/bin/$tool_bin"
+      echo "Info: linked /usr/local/bin/$tool_bin -> $HOME/.local/bin/$tool_bin"
+    fi
+  done
+else
+  echo "Warning: sudo not available; skipping /usr/local/bin symlinks for codex/opencode"
+fi
+
 start_chrome_cdp_systemd
 
 OPENCODE_BIN=""


### PR DESCRIPTION
## Changes

- install_paperclip(): runs pnpm -r build after pnpm install to compile source
- New start_paperclip(): kills old processes, starts from source CLI dist, waits for health
- Bootstrap sequence calls start_paperclip after install_paperclip

## Motivation

The paperclip fork has been patched to add github-copilot/* models to the opencode-local adapter. Running from source ensures model changes are permanent.

Closes #20