### PR TITLE
fix: match tsx paperclip runtime processes during restart

### DIFF
--- a/codebox.ts
+++ b/codebox.ts
@@ -2244,7 +2244,7 @@ start_paperclip() {
   local pids
   local legacy_pattern="$PAPERCLIP_DIR/cli/dist/index.js onboard"
   local pnpm_pattern="paperclipai dev onboard"
-  local tsx_pattern="src/index.ts onboard"
+  local tsx_pattern="$PAPERCLIP_DIR.*src/index.ts onboard|src/index.ts onboard.*$PAPERCLIP_DIR"
   pids="$( (pgrep -f "$legacy_pattern" 2>/dev/null || true; pgrep -f "$pnpm_pattern" 2>/dev/null || true; pgrep -f "$tsx_pattern" 2>/dev/null || true) | sort -u )"
   if [ -n "$pids" ]; then
     echo "Info: Killing existing paperclip processes: $pids"

--- a/codebox.ts
+++ b/codebox.ts
@@ -2244,7 +2244,7 @@ start_paperclip() {
   local pids
   local legacy_pattern="$PAPERCLIP_DIR/cli/dist/index.js onboard"
   local pnpm_pattern="paperclipai dev onboard"
-  local tsx_pattern="tsx src/index.ts onboard"
+  local tsx_pattern="src/index.ts onboard"
   pids="$( (pgrep -f "$legacy_pattern" 2>/dev/null || true; pgrep -f "$pnpm_pattern" 2>/dev/null || true; pgrep -f "$tsx_pattern" 2>/dev/null || true) | sort -u )"
   if [ -n "$pids" ]; then
     echo "Info: Killing existing paperclip processes: $pids"


### PR DESCRIPTION
## Summary
- broaden tsx runtime matching to include generic src/index.ts onboard process forms
- retain legacy dist and pnpm matching

## Validation
- npm test

Closes #27